### PR TITLE
Rank fixes and changes

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/basic/OfflineUser.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/OfflineUser.java
@@ -119,7 +119,10 @@ public class OfflineUser implements OfflinePlayer, ConfigurationSerializable {
         return Bukkit.getServer().getBannedPlayers().contains(this);
     }
     
-    public void setBanned(boolean value) {}
+    @SuppressWarnings("deprecation")
+    public void setBanned(boolean value) {
+        getReal().setBanned(value);
+    }
 
     public boolean isWhitelisted() {
         return Bukkit.getWhitelistedPlayers().contains(this);

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/OfflineUser.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/OfflineUser.java
@@ -118,6 +118,8 @@ public class OfflineUser implements OfflinePlayer, ConfigurationSerializable {
         }
         return Bukkit.getServer().getBannedPlayers().contains(this);
     }
+    
+    public void setBanned(boolean value) {}
 
     public boolean isWhitelisted() {
         return Bukkit.getWhitelistedPlayers().contains(this);

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/OfflineUser.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/OfflineUser.java
@@ -119,11 +119,6 @@ public class OfflineUser implements OfflinePlayer, ConfigurationSerializable {
         return Bukkit.getServer().getBannedPlayers().contains(this);
     }
 
-    @SuppressWarnings("deprecation")
-    public void setBanned(boolean value) {
-        getReal().setBanned(value);
-    }
-
     public boolean isWhitelisted() {
         return Bukkit.getWhitelistedPlayers().contains(this);
     }

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/util/RankSystem.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/util/RankSystem.java
@@ -1,0 +1,8 @@
+package net.dzikoysk.funnyguilds.basic.util;
+
+public enum RankSystem {
+
+    ELO,
+    PERCENT,
+    STATIC
+}

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/util/RankSystem.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/util/RankSystem.java
@@ -5,4 +5,5 @@ public enum RankSystem {
     ELO,
     PERCENT,
     STATIC
+	
 }

--- a/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerDeath.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerDeath.java
@@ -71,6 +71,9 @@ public class PlayerDeath implements Listener {
             rankChanges[0] = Settings.getConfig().staticAttackerChange;
             rankChanges[1] = Settings.getConfig().staticVictimChange;
             break;
+        default:
+            rankChanges = EloUtils.getRankChanges(attacker.getRank(), victim.getRank());
+            break;
         }
 
         attacker.getRank().addKill();

--- a/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerDeath.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerDeath.java
@@ -18,9 +18,6 @@ import net.dzikoysk.funnyguilds.util.thread.IndependentThread;
 
 public class PlayerDeath implements Listener {
 
-    public static long victimCooldown = 7200000L;
-    private static long attackerCooldown = 7200000L;
-
     @EventHandler
     public void onDeath(PlayerDeathEvent event) {
         Player v = event.getEntity();
@@ -43,21 +40,38 @@ public class PlayerDeath implements Listener {
 
         if (Settings.getConfig().rankFarmingProtect) {
             if (attacker.getLastVictim() != null && attacker.getLastVictim().equals(victim)) {
-                if (attacker.getLastVictimTime() + attackerCooldown > System.currentTimeMillis()) {
+                if (attacker.getLastVictimTime() + (Settings.getConfig().rankFarmingCooldown * 1000) > System.currentTimeMillis()) {
                     v.sendMessage(Messages.getInstance().rankLastVictimV);
                     a.sendMessage(Messages.getInstance().rankLastVictimA);
+                    event.setDeathMessage(null);
                     return;
                 }
             } else if (victim.getLastAttacker() != null && victim.getLastAttacker().equals(attacker)) {
-                if (victim.getLastVictimTime() + victimCooldown > System.currentTimeMillis()) {
+                if (victim.getLastVictimTime() + (Settings.getConfig().rankFarmingCooldown * 1000) > System.currentTimeMillis()) {
                     v.sendMessage(Messages.getInstance().rankLastAttackerV);
                     a.sendMessage(Messages.getInstance().rankLastAttackerA);
+                    event.setDeathMessage(null);
                     return;
                 }
             }
         }
 
-        int[] rankChanges = EloUtils.getRankChanges(attacker.getRank(), victim.getRank());
+        int[] rankChanges = new int[2];
+        
+        switch(Settings.getConfig().rankSystem) {
+        case ELO:
+            rankChanges = EloUtils.getRankChanges(attacker.getRank(), victim.getRank());
+            break;
+        case PERCENT:
+            Double d = victim.getRank().getPoints() * (Settings.getConfig().percentRankChange / 100);
+            rankChanges[0] = d.intValue();
+            rankChanges[1] = d.intValue();
+            break;
+        case STATIC:
+            rankChanges[0] = Settings.getConfig().staticAttackerChange;
+            rankChanges[1] = Settings.getConfig().staticVictimChange;
+            break;
+        }
 
         attacker.getRank().addKill();
         attacker.getRank().addPoints(rankChanges[0]);

--- a/src/main/java/net/dzikoysk/funnyguilds/util/NotePitch.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/util/NotePitch.java
@@ -51,11 +51,20 @@ public enum NotePitch {
                 return note.pitch;
             }
         }
+        
         return 0.0F;
     }
 
     public static void play(Player player, int octave, Tone tone) {
-        player.playSound(player.getEyeLocation(), Sound.NOTE_PIANO, 1, NotePitch.getPitch(octave, tone));
+        Sound s = null;
+        
+        try {
+            s = Sound.valueOf("NOTE_PIANO");
+        } catch (Exception e) {
+            s = Sound.valueOf("BLOCK_NOTE_HARP");
+        }
+        
+        player.playSound(player.getEyeLocation(), s, 1, NotePitch.getPitch(octave, tone));
     }
 
 }

--- a/src/main/java/net/dzikoysk/funnyguilds/util/elo/EloUtils.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/util/elo/EloUtils.java
@@ -77,10 +77,10 @@ public class EloUtils {
     public static int[] getRankChanges(Rank attacker, Rank victim) {
         int aP = attacker.getPoints();
         int vP = victim.getPoints();
-
+        
         return new int[]{
-                (int) Math.round(aP + EloUtils.getConstantForRank(aP) * (1 - (1.0D / (1.0D + Math.pow(Settings.getConfig().eloExponent, (vP - aP) / Settings.getConfig().eloDivider))))),
-                (int) Math.round(vP + EloUtils.getConstantForRank(vP) * (0 - (1.0D / (1.0D + Math.pow(Settings.getConfig().eloExponent, (aP - vP) / Settings.getConfig().eloDivider)))))
+                (int) Math.round(EloUtils.getConstantForRank(aP) * (1 - (1.0D / (1.0D + Math.pow(Settings.getConfig().eloExponent, (vP - aP) / Settings.getConfig().eloDivider))))),
+                (int) Math.round(EloUtils.getConstantForRank(vP) * (0 - (1.0D / (1.0D + Math.pow(Settings.getConfig().eloExponent, (aP - vP) / Settings.getConfig().eloDivider)))) * -1)
         };
     }
 


### PR DESCRIPTION
**1.** Usunięcie metody setBanned() z klasy OfflineUser z powodu braku metody setBanned() w klasie OfflinePlayer na wersji 1.12 (metoda i tak była nieużywana)
**2.** Dodanie enumu RankSystem i ustanowienie trzech systemów rankingu - ELO, procentowego i statycznego
**3.** Dodanie do configu zmiennej z czasem, który musi upłynąć od walki, aby znowu naliczało ranking
**4.** Poprawienie klasy NotePitch, aby była kompatybilna ze wszystkimi wersjami MC od 1.8 w górę
**5.** Zmiany w configu - usunięcie _Tribute_ z nazwy, dodanie informacji o możliwości podania metadaty do itemu

Ze względu na wcześniejszy błąd w rankingu ELO i dzisiejsze zmiany - jestem za jak najszybszym wydaniem nowego release