### PR TITLE
Add update info toggle

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/data/configs/PluginConfig.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/configs/PluginConfig.java
@@ -45,6 +45,10 @@ public class PluginConfig {
     @CfgComment("Wyswietlana nazwa pluginu")
     @CfgName("plugin-name")
     public String pluginName = "FunnyGuilds";
+    
+    @CfgComment("Czy informacje o aktualizacji maja byc widoczne podczas wejscia na serwer")
+    @CfgName("update-info")
+    public boolean updateInfo = true;
 
     @CfgComment("Mozliwosc zakladania gildii (mozna zmienic takze za pomoca komendy /ga enabled)")
     @CfgName("guilds-enabled")

--- a/src/main/java/net/dzikoysk/funnyguilds/util/Version.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/util/Version.java
@@ -1,6 +1,8 @@
 package net.dzikoysk.funnyguilds.util;
 
 import net.dzikoysk.funnyguilds.FunnyGuilds;
+import net.dzikoysk.funnyguilds.data.Settings;
+
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -9,7 +11,11 @@ public final class Version {
     public static final String VERSION_FILE_URL = "https://funnyguilds.dzikoysk.net/latest.info";
 
     public static void isNewAvailable(final Player player) {
-        if (!player.hasPermission("funnyguilds.admin") && !player.isOp()) {
+        if (!Settings.getConfig().updateInfo) {
+            return;
+        }
+        
+        if (!player.hasPermission("funnyguilds.admin")) {
             return;
         }
 


### PR DESCRIPTION
Tak naprawdę jest to scalenie #693 i #694 z przerobieniem nazewnictwa sekcji w configu, aby pasowała do reszty i z poprawieniem warunku sprawdzającego permission i stan włączenia informacji o aktualizacji, aby faktycznie działał jak należy

Dzięki @RabbitTheDEV za poddanie pomysłu na zmiany, ale szybciej będzie jeśli po prostu sam zrobię obie te zmiany w jednym PR :)