### PR TITLE
Make bugged blocks less bugged

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,8 +149,9 @@
             <url>http://maven.sk89q.com/repo/</url>
         </repository>
         <repository>
-            <id>vault-repo</id>
-            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+            <id>okaeri</id>
+            <name>Okaeri Repository</name>
+            <url>https://repo.okaeri.eu/</url>
         </repository>
         <repository>
             <id>placeholderapi</id>

--- a/src/main/java/net/dzikoysk/funnyguilds/data/configs/PluginConfiguration.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/configs/PluginConfiguration.java
@@ -385,7 +385,23 @@ public class PluginConfiguration {
     @CfgName("bugged-blocks-exclude")
     @CfgStringStyle(StringStyle.ALWAYS_QUOTED)
     @CfgCollectionStyle(CollectionStyle.ALWAYS_NEW_LINE)
-    public List<String> buggedBlocksExclude_ = Arrays.asList("TNT", "STATIONARY_LAVA", "STATIONARY_WATER");
+    public List<String> buggedBlocksExclude_ = Arrays.asList(
+            // Ban basic
+            "TNT", "STATIONARY_LAVA", "STATIONARY_WATER",
+            // Ban TNT Minecart placement
+            "RAILS", "DETECTOR_RAIL", "ACTIVATOR_RAIL", "POWERED_RAIL",
+            // Ban gravity blocks that won't be removed when fallen
+            "ANVIL", "GRAVEL", "SAND", "DRAGON_EGG",
+            // Ban pistons and other components that may produce redstone output or interact with it
+            "PISTON_BASE", "PISTON_STICKY_BASE",
+            "REDSTONE_BLOCK", "REDSTONE_TORCH_ON", "REDSTONE_TORCH_OFF", "DIODE", "REDSTONE_COMPARATOR", "DAYLIGHT_DETECTOR",
+            "DISPENSER", "HOPPER", "DROPPER", "OBSERVER",
+            "STONE_PLATE", "WOOD_PLATE", "GOLD_PLATE", "IRON_PLATE", "LEVER", "TRIPWIRE_HOOK", "TRAP_DOOR", "IRON_TRAPDOOR", "WOOD_BUTTON", "STONE_BUTTON",
+            "WOOD_DOOR", "IRON_DOOR", "SPRUCE_DOOR_ITEM", "BIRCH_DOOR_ITEM", "JUNGLE_DOOR_ITEM", "ACACIA_DOOR_ITEM", "DARK_OAK_DOOR_ITEM",
+            "FENCE_GATE", "SPRUCE_FENCE_GATE", "JUNGLE_FENCE_GATE", "DARK_OAK_FENCE_GATE", "BIRCH_FENCE_GATE",
+            "REDSTOE_LAMP_ON", "REDSTOE_LAMP_OFF",
+            "TRAPPED_CHEST", "CHEST"
+            );
 
     @CfgExclude
     public Set<Material> buggedBlocksExclude;


### PR DESCRIPTION
**Fixing default bugged-blocks-exclude configuration by adjusting it with the following:**
- Prevent using tnt minecarts by placing rails
- Prevent moving/removing blocks from other guilds using pistons
- Prevent using all other blocks that may produce redstone output to prevent further exploits

**Reasons and motivation:**
It is expected from this functionality to allow escapes from terrain of enemy guilds that cannot be escaped normally (artificial pits in terrain), not to allow full bypass of region protection.