### PR TITLE
Stop bugged blocks from breaking in some way almost all plugins executing actions after BlockPlaceEvent

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockPlace.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockPlace.java
@@ -18,6 +18,8 @@ import org.bukkit.util.Vector;
 
 public class BlockPlace implements Listener {
 
+    private static final Vector ANTI_GLITCH_VELOCITY = new Vector(0, 0.4, 0);
+
     private final PluginConfiguration config = FunnyGuilds.getInstance().getPluginConfiguration();
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -60,11 +62,11 @@ public class BlockPlace implements Listener {
         double distanceUp = (playerLocation.getY() - blockLocation.getBlockY());
         boolean upToTwoBlocks = (distanceUp > 0) && (distanceUp <= 2);
         if (sameColumn && upToTwoBlocks) {
-            player.setVelocity(new Vector(0, 0.4, 0));
+            player.setVelocity(ANTI_GLITCH_VELOCITY);
         }
 
         // delay, because we cannot do {@link Block#setType(Material)} immediately
-        Bukkit.getScheduler().runTaskLater(FunnyGuilds.getInstance(), () -> {
+        Bukkit.getScheduler().runTask(FunnyGuilds.getInstance(), () -> {
 
             // fake place for bugged block
             block.setType(type);
@@ -83,7 +85,7 @@ public class BlockPlace implements Listener {
                 }
             }, this.config.buggedBlocksTimer);
 
-        }, 0);
+        });
     }
 
 }

--- a/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockPlace.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockPlace.java
@@ -3,35 +3,87 @@ package net.dzikoysk.funnyguilds.listener.region;
 import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.data.configs.PluginConfiguration;
 import net.dzikoysk.funnyguilds.system.protection.ProtectionSystem;
+import net.dzikoysk.funnyguilds.util.nms.Reflections;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 
 public class BlockPlace implements Listener {
 
     private final PluginConfiguration config = FunnyGuilds.getInstance().getPluginConfiguration();
 
-    @EventHandler
-    public void onPlace(BlockPlaceEvent e) {
-        if (ProtectionSystem.build(e.getPlayer(), e.getBlock().getLocation(), true)) {
-            if (config.buggedBlocks && !config.buggedBlocksExclude.contains(e.getBlock().getType())) {
-                ItemStack returnItem = e.getItemInHand().clone();
-                returnItem.setAmount(1);
-                Bukkit.getScheduler().runTaskLater(FunnyGuilds.getInstance(), () -> {
-                    e.getBlockReplacedState().update(true);
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlace(BlockPlaceEvent event) {
+        Player player = event.getPlayer();
+        Block block = event.getBlock();
+        Material type = block.getType();
 
-                    if (config.buggedBlockReturn) {
-                        e.getPlayer().getInventory().addItem(returnItem);
-                    }
-                }, config.buggedBlocksTimer);
-
-                return;
-            }
-
-            e.setCancelled(true);
+        Location blockLocation = block.getLocation();
+        if (!ProtectionSystem.build(player, blockLocation, true)) {
+            return;
         }
+
+        // always cancel to prevent breaking other protection
+        // plugins or plugins using BlockPlaceEvent (eg. special ability blocks)
+        event.setCancelled(true);
+
+        // disabled bugged-blocks or blacklisted item
+        if (!this.config.buggedBlocks || this.config.buggedBlocksExclude.contains(type)) {
+            return;
+        }
+
+        // remove one item from the player
+        ItemStack itemInHand = event.getItemInHand();
+        if ((itemInHand.getAmount() - 1) == 0) {
+            // wondering why? because bukkit and you probably don't want dupe glitches
+            if (Reflections.USE_PRE_9_METHODS) {
+                player.setItemInHand(null);
+            } else {
+                itemInHand.setAmount(0);
+            }
+        } else {
+            itemInHand.setAmount(itemInHand.getAmount() - 1);
+        }
+
+        // if the player is standing on the placed block add some velocity to prevent glitching
+        // side effect: velocity with +y0.4 is like equivalent to jumping while building, just hold right click, that's real fun!
+        Location playerLocation = player.getLocation();
+        boolean sameColumn = (playerLocation.getBlockX() == blockLocation.getBlockX()) && (playerLocation.getBlockZ() == blockLocation.getBlockZ());
+        double distanceUp = (playerLocation.getY() - blockLocation.getBlockY());
+        boolean upToTwoBlocks = (distanceUp > 0) && (distanceUp <= 2);
+        if (sameColumn && upToTwoBlocks) {
+            player.setVelocity(new Vector(0, 0.4, 0));
+        }
+
+        // delay, because we cannot do {@link Block#setType(Material)} immediately
+        Bukkit.getScheduler().runTaskLater(FunnyGuilds.getInstance(), () -> {
+
+            // fake place for bugged block
+            block.setType(type);
+
+            // start timer and return the item to the player if specified to do so
+            ItemStack returnItem = event.getItemInHand().clone();
+            returnItem.setAmount(1);
+
+            Bukkit.getScheduler().runTaskLater(FunnyGuilds.getInstance(), () -> {
+                event.getBlockReplacedState().update(true);
+                if (!player.isOnline()) {
+                    return;
+                }
+                if (this.config.buggedBlockReturn) {
+                    player.getInventory().addItem(returnItem);
+                }
+            }, this.config.buggedBlocksTimer);
+
+        }, 0);
     }
 
 }

--- a/src/main/java/net/dzikoysk/funnyguilds/util/nms/Reflections.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/util/nms/Reflections.java
@@ -18,7 +18,8 @@ public final class Reflections {
     public static final String SERVER_VERSION = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
     public static final boolean USE_PRE_13_METHODS = Integer.parseInt(SERVER_VERSION.split("_")[1]) < 13;
     public static final boolean USE_PRE_12_METHODS = Integer.parseInt(SERVER_VERSION.split("_")[1]) < 12;
-    
+    public static final boolean USE_PRE_9_METHODS = Integer.parseInt(SERVER_VERSION.split("_")[1]) < 9;
+
     private static final Map<String, Class<?>> CLASS_CACHE = new HashMap<>();
     private static final Map<String, Field> FIELD_CACHE = new HashMap<>();
     private static final Map<String, FieldAccessor<?>> FIELD_ACCESSOR_CACHE = new HashMap<>();


### PR DESCRIPTION
While being popularized in the guilds community, current implementation was unusable with other plugins (especially with plugins modifying terrain around after block place). This PR changes completely how bugged blocks function works under the hood.

It has some drawbacks, but I believe it is overall better and more fun for users. Players can just hold a right click after first jump to build a tower and combined with clicking the space bar it can be even faster towering method, which enables more skill based gameplay during guild wars.