### PR TITLE
Fix interaction between our plugin and others while handling explosion event

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/listener/TntProtection.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/TntProtection.java
@@ -15,7 +15,7 @@ import java.util.Iterator;
 
 public class TntProtection implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onExplode(EntityExplodeEvent event) {
         PluginConfiguration config = FunnyGuilds.getInstance().getPluginConfiguration();
 

--- a/src/main/java/net/dzikoysk/funnyguilds/util/commons/bukkit/SpaceUtils.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/util/commons/bukkit/SpaceUtils.java
@@ -1,10 +1,15 @@
 package net.dzikoysk.funnyguilds.util.commons.bukkit;
 
 import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.panda_lang.utilities.commons.function.QuadFunction;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 
 public final class SpaceUtils {
 
@@ -12,26 +17,40 @@ public final class SpaceUtils {
         return chance >= 100 || chance > ThreadLocalRandom.current().nextDouble(0, 100);
     }
     
-    public static List<Location> sphere(Location loc, int radius, int height, boolean hollow, boolean sphere, int plusY) {
-        List<Location> circleBlocks = new ArrayList<>();
-        int explosionX = loc.getBlockX();
-        int explosionY = loc.getBlockY();
-        int explosionZ = loc.getBlockZ();
+    public static List<Location> sphere(Location sphereCenter, int radius, int height, boolean hollow, boolean sphere, int plusY) {
+        return mapSphereCoordinates(sphereCenter, radius, height, plusY, hollow, sphere, ArrayList::new, Location::new);
+    }
 
-        for (int x = explosionX - radius; x <= explosionX + radius; x++) {
-            for (int z = explosionZ - radius; z <= explosionZ + radius; z++) {
-                for (int y = (sphere ? explosionY - radius : explosionY); y < (sphere ? explosionY + radius : explosionY + height); y++) {
-                    double dist = (explosionX - x) * (explosionX - x) + (explosionZ - z) * (explosionZ - z) + (sphere ? (explosionY - y) * (explosionY - y) : 0);
+    public static List<Block> sphereBlocks(Location sphereLocation, int radius, int height, int plusY, boolean hollow, boolean sphere) {
+        return mapSphereCoordinates(sphereLocation, radius, height, plusY, hollow, sphere, ArrayList::new, World::getBlockAt);
+    }
+
+    private static <T, C extends Collection<T>> C mapSphereCoordinates(Location sphereCenter,
+                                                                       int radius, int height, int plusY,
+                                                                       boolean hollow, boolean sphere,
+                                                                       Supplier<C> collectionSupplier,
+                                                                       QuadFunction<World, Integer, Integer, Integer, T> coordinateMapper) {
+
+        C result = collectionSupplier.get();
+
+        World world = sphereCenter.getWorld();
+        int centerX = sphereCenter.getBlockX();
+        int centerY = sphereCenter.getBlockY();
+        int centerZ = sphereCenter.getBlockZ();
+
+        for (int x = centerX - radius; x <= centerX + radius; x++) {
+            for (int z = centerZ - radius; z <= centerZ + radius; z++) {
+                for (int y = (sphere ? centerY - radius : centerY); y < (sphere ? centerY + radius : centerY + height); y++) {
+                    double dist = (centerX - x) * (centerX - x) + (centerZ - z) * (centerZ - z) + (sphere ? (centerY - y) * (centerY - y) : 0);
 
                     if (dist < radius * radius && !(hollow && dist < (radius - 1) * (radius - 1))) {
-                        Location l = new Location(loc.getWorld(), x, y + plusY, z);
-                        circleBlocks.add(l);
+                        result.add(coordinateMapper.apply(world, x, y + plusY, z));
                     }
                 }
             }
         }
 
-        return circleBlocks;
+        return result;
     }
 
     private SpaceUtils() {}


### PR DESCRIPTION
Previously, we've been handling explosion event improperly, because we've not been taking into an account the fact that other plugins (for example WorldGuard) often doesn't cancel the event, but instead they are clearing the list of the blocks that have been affected by the explosion and because of that our custom block explosion logic could be fired even if it shouldn't be.

Now, we're calculating all the blocks that we need for our purposes before most of the protection (but not only) plugins code is fired and modifying the explosion event block list so that blocks that we're interested in are included, then let other plugins run their event handlers, and then based on the resulting event data we can handle explosion event properly without breaking interaction with other plugins.

Closes #1446.