### PR TITLE
Get the regionOther message out of the util class

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockBreak.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockBreak.java
@@ -12,6 +12,7 @@ public class BlockBreak implements Listener {
     public void onBreak(BlockBreakEvent event) {
         if (ProtectionSystem.isProtected(event.getPlayer(), event.getBlock().getLocation(), FunnyGuilds.getInstance().getPluginConfiguration().regionExplodeBlockBreaking)) {
             event.setCancelled(true);
+            event.getPlayer().sendMessage(FunnyGuilds.getInstance().getMessageConfiguration().regionOther);
         }
     }
 

--- a/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockIgnite.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockIgnite.java
@@ -1,5 +1,6 @@
 package net.dzikoysk.funnyguilds.listener.region;
 
+import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.system.protection.ProtectionSystem;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -11,6 +12,7 @@ public class BlockIgnite implements Listener {
     public void onIgnite(BlockIgniteEvent e) {
         if (ProtectionSystem.isProtected(e.getPlayer(), e.getBlock().getLocation())) {
             e.setCancelled(true);
+            e.getPlayer().sendMessage(FunnyGuilds.getInstance().getMessageConfiguration().regionOther);
         }
     }
 

--- a/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockPlace.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/region/BlockPlace.java
@@ -36,6 +36,7 @@ public class BlockPlace implements Listener {
         // always cancel to prevent breaking other protection
         // plugins or plugins using BlockPlaceEvent (eg. special ability blocks)
         event.setCancelled(true);
+        player.sendMessage(FunnyGuilds.getInstance().getMessageConfiguration().regionOther);
 
         // disabled bugged-blocks or blacklisted item
         if (!this.config.buggedBlocks || this.config.buggedBlocksExclude.contains(type)) {

--- a/src/main/java/net/dzikoysk/funnyguilds/listener/region/BucketAction.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/region/BucketAction.java
@@ -1,5 +1,6 @@
 package net.dzikoysk.funnyguilds.listener.region;
 
+import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.system.protection.ProtectionSystem;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -12,6 +13,7 @@ public class BucketAction implements Listener {
     public void onFill(PlayerBucketFillEvent e) {
         if (ProtectionSystem.isProtected(e.getPlayer(), e.getBlockClicked().getLocation())) {
             e.setCancelled(true);
+            e.getPlayer().sendMessage(FunnyGuilds.getInstance().getMessageConfiguration().regionOther);
         }
     }
 
@@ -19,6 +21,7 @@ public class BucketAction implements Listener {
     public void onEmpty(PlayerBucketEmptyEvent e) {
         if (ProtectionSystem.isProtected(e.getPlayer(), e.getBlockClicked().getLocation())) {
             e.setCancelled(true);
+            e.getPlayer().sendMessage(FunnyGuilds.getInstance().getMessageConfiguration().regionOther);
         }
     }
 

--- a/src/main/java/net/dzikoysk/funnyguilds/listener/region/EntityPlace.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/listener/region/EntityPlace.java
@@ -1,5 +1,6 @@
 package net.dzikoysk.funnyguilds.listener.region;
 
+import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.system.protection.ProtectionSystem;
 import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.Entity;
@@ -21,6 +22,7 @@ public class EntityPlace implements Listener {
 
         if (ProtectionSystem.isProtected(player, entity.getLocation(), true)) {
             event.setCancelled(true);
+            player.sendMessage(FunnyGuilds.getInstance().getMessageConfiguration().regionOther);
         }
     }
 }

--- a/src/main/java/net/dzikoysk/funnyguilds/system/protection/ProtectionSystem.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/system/protection/ProtectionSystem.java
@@ -52,7 +52,6 @@ public final class ProtectionSystem {
             return false;
         }
 
-        player.sendMessage(FunnyGuilds.getInstance().getMessageConfiguration().regionOther);
         return true;
     }
 


### PR DESCRIPTION
This allows other plugins to check if blocks are protected without spamming the player with regionOther message.