### PR TITLE
Enhance startup errors, make FunnyGuildsLogger print full stacktrace instead of first part

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
@@ -107,11 +107,10 @@ public class FunnyGuilds extends JavaPlugin {
             });
         }
         catch (Exception exception) {
-            if (exception instanceof OkaeriException) {
-                logger.error("Could not initialize plugin configuration", exception.getCause());
-            } else {
-                logger.error("Could not load plugin configuration", exception);
+            while (exception.getCause() instanceof OkaeriException) {
+                exception = (Exception) exception.getCause();
             }
+            logger.error("Could not load plugin configuration", exception);
             shutdown("Critical error has been encountered!");
             return;
         }

--- a/src/main/java/net/dzikoysk/funnyguilds/FunnyGuildsLogger.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/FunnyGuildsLogger.java
@@ -1,5 +1,7 @@
 package net.dzikoysk.funnyguilds;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -56,10 +58,12 @@ public final class FunnyGuildsLogger {
         error("");
         error(content);
         error("");
-        error(cause.toString());
 
-        for (StackTraceElement element : cause.getStackTrace()) {
-            error("       at " + element.toString());
+        StringWriter errorDump = new StringWriter();
+        cause.printStackTrace(new PrintWriter(errorDump));
+
+        for (String line : errorDump.toString().split("\n")) {
+            error(line);
         }
 
         error("");


### PR DESCRIPTION
At the moment the plugin is hiding the real error cause of some issues, this PR fixes it by making sure the full stacktrace is visible.