### PR TITLE
Simple protection time system rework.

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/basic/guild/Guild.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/guild/Guild.java
@@ -36,11 +36,10 @@ public class Guild extends AbstractBasic {
     private long       born;
     private long       validity;
     private Date       validityDate;
-    private long       attacked;
+    private long       protection;
     private long       ban;
     private int        lives;
     private long       build;
-    private long       additionalProtection;
     private Set<UUID>  alliedFFGuilds;
 
     private Guild(UUID uuid) {
@@ -149,7 +148,7 @@ public class Guild extends AbstractBasic {
     }
 
     public boolean canBeAttacked() {
-        return this.getProtectionEndTime() < System.currentTimeMillis() && this.additionalProtection < System.currentTimeMillis();
+        return this.getProtection() < System.currentTimeMillis();
     }
 
     public void addDeputy(User user) {
@@ -164,10 +163,6 @@ public class Guild extends AbstractBasic {
     public void removeDeputy(User user) {
         this.deputies.remove(user);
         this.markChanged();
-    }
-
-    public void setAdditionalProtection(long timestamp) {
-        this.additionalProtection = timestamp;
     }
 
     public void setName(String name) {
@@ -262,8 +257,8 @@ public class Guild extends AbstractBasic {
         this.markChanged();
     }
 
-    public void setAttacked(long l) {
-        this.attacked = l;
+    public void setProtection(long protection) {
+        this.protection = protection;
         this.markChanged();
     }
 
@@ -295,14 +290,6 @@ public class Guild extends AbstractBasic {
 
     public void setEnderCrystal(Location loc) {
         this.enderCrystal = loc;
-    }
-
-    public long getProtectionEndTime() {
-        return this.attacked == this.born ? this.attacked + FunnyGuilds.getInstance().getPluginConfiguration().warProtection : this.attacked + FunnyGuilds.getInstance().getPluginConfiguration().warWait;
-    }
-
-    public long getAdditionalProtectionEndTime() {
-        return this.additionalProtection;
     }
 
     public boolean isSomeoneInRegion() {
@@ -389,8 +376,8 @@ public class Guild extends AbstractBasic {
         return this.validityDate == null ? this.validityDate = new Date(this.validity) : this.validityDate;
     }
 
-    public long getAttacked() {
-        return this.attacked;
+    public long getProtection() {
+        return this.protection;
     }
 
     public int getLives() {

--- a/src/main/java/net/dzikoysk/funnyguilds/command/admin/ProtectionCommand.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/command/admin/ProtectionCommand.java
@@ -25,7 +25,7 @@ public final class ProtectionCommand {
     )
     public void execute(MessageConfiguration messages, CommandSender sender, String[] args) {
         when (args.length < 1, messages.generalNoTagGiven);
-        when (args.length < 3, messages.adminNoAdditionalProtectionDateGiven);
+        when (args.length < 3, messages.adminNoProtectionDateGive);
 
         Guild guild = GuildValidation.requireGuildByTag(args[0]);
 
@@ -35,17 +35,17 @@ public final class ProtectionCommand {
         try {
             protectionDate = PROTECTION_DATE_FORMAT.parse(protectionDateAsString);
         } catch (ParseException e) {
-            sender.sendMessage(messages.adminInvalidAdditionalProtectionDate);
+            sender.sendMessage(messages.adminInvalidProtectionDate);
             return;
         }
 
-        guild.setAdditionalProtection(protectionDate.getTime());
+        guild.setProtection(protectionDate.getTime());
 
         Formatter formatter = new Formatter()
                 .register("{TAG}", guild.getTag())
                 .register("{DATE}", protectionDateAsString);
 
 
-        sender.sendMessage(formatter.format(messages.adminAdditionalProtectionSetSuccessfully));
+        sender.sendMessage(formatter.format(messages.adminProtectionSetSuccessfully));
     }
 }

--- a/src/main/java/net/dzikoysk/funnyguilds/command/user/CreateCommand.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/command/user/CreateCommand.java
@@ -151,7 +151,7 @@ public final class CreateCommand {
         guild.setLives(config.warLives);
         guild.setBorn(System.currentTimeMillis());
         guild.setValidity(System.currentTimeMillis() + config.validityStart);
-        guild.setAttacked(System.currentTimeMillis() - config.warWait + config.warProtection);
+        guild.setProtection(System.currentTimeMillis() + config.warProtection);
         guild.setPvP(config.damageGuild);
         guild.setHome(guildLocation);
 

--- a/src/main/java/net/dzikoysk/funnyguilds/command/user/InfoCommand.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/command/user/InfoCommand.java
@@ -48,8 +48,7 @@ public final class InfoCommand {
         String validity = config.dateFormat.format(new Date(guild.getValidity()));
         
         long now = System.currentTimeMillis();
-        long protectionEndTime = guild.getProtectionEndTime();
-        long additionalProtectionEndTime = guild.getAdditionalProtectionEndTime();
+        long protectionEndTime = guild.getProtection();
 
         for (String messageLine : messages.infoList) {
             messageLine = StringUtils.replace(messageLine, "{GUILD}", guild.getName());
@@ -61,7 +60,6 @@ public final class InfoCommand {
             messageLine = StringUtils.replace(messageLine, "{DEPUTIES}", guild.getDeputies().isEmpty() ? "Brak" : ChatUtils.toString(UserUtils.getNames(guild.getDeputies()), true));
             messageLine = StringUtils.replace(messageLine, "{REGION-SIZE}", config.regionsEnabled ? String.valueOf(guild.getRegion().getSize()) : messages.gRegionSizeNoValue);
             messageLine = StringUtils.replace(messageLine, "{GUILD-PROTECTION}", protectionEndTime < now ? "Brak" : TimeUtils.getDurationBreakdown(protectionEndTime - now));
-            messageLine = StringUtils.replace(messageLine, "{GUILD-ADDITIONAL-PROTECTION}", additionalProtectionEndTime < now ? "Brak" : TimeUtils.getDurationBreakdown(additionalProtectionEndTime - now));
 
             Rank rank = guild.getRank();
             messageLine = StringUtils.replace(messageLine, "{POINTS-FORMAT}", IntegerRange.inRangeToString(rank.getPoints(), config.pointsFormat));

--- a/src/main/java/net/dzikoysk/funnyguilds/data/configs/MessageConfiguration.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/configs/MessageConfiguration.java
@@ -164,6 +164,7 @@ public class MessageConfiguration extends OkaeriConfig {
             "&a/ga zycia [tag] [zycia] &8- &7Ustawia liczbe zyc gildii",
             "&a/ga przenies [tag] &8- &7Przenosi teren gildii",
             "&a/ga przedluz [tag] [czas] &8- &7Przedluza waznosc gildii o podany czas",
+            "&a/ga ochrona [tag] [czas] &8- &7Ustawia date wygasniecia ochrony",
             "&a/ga nazwa [tag] [nazwa] &8- &7Zmienia nazwe gildii",
             "&a/ga tag [tag] [nowy tag] &8- &7Zmienia tag gildii",
             "&a/ga spy &8- &7Szpieguje czat gildii",

--- a/src/main/java/net/dzikoysk/funnyguilds/data/configs/MessageConfiguration.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/configs/MessageConfiguration.java
@@ -197,7 +197,7 @@ public class MessageConfiguration extends OkaeriConfig {
     public String infoTag = "&cPodaj tag gildii!";
     public String infoExists = "&cGildia o takim tagu nie istnieje!";
 
-    @Comment("Dostepne zmienne: {GUILD}, {TAG}, {OWNER}, {DEPUTIES}, {MEMBERS}, {MEMBERS-ONLINE}, {MEMBERS-ALL}, {REGION-SIZE}, {POINTS}, {POINTS-FORMAT}, {KILLS}, {DEATHS}, {ASSISTS}, {LOGOUTS}, {KDR}, {ALLIES}, {ALLIES-TAGS}, {ENEMIES}, {ENEMIES-TAGS}, {RANK}, {VALIDITY}, {LIVES}, {GUILD-PROTECTION}, {GUILD-ADDITIONAL-PROTECTION}")
+    @Comment("Dostepne zmienne: {GUILD}, {TAG}, {OWNER}, {DEPUTIES}, {MEMBERS}, {MEMBERS-ONLINE}, {MEMBERS-ALL}, {REGION-SIZE}, {POINTS}, {POINTS-FORMAT}, {KILLS}, {DEATHS}, {ASSISTS}, {LOGOUTS}, {KDR}, {ALLIES}, {ALLIES-TAGS}, {ENEMIES}, {ENEMIES-TAGS}, {RANK}, {VALIDITY}, {LIVES}, {GUILD-PROTECTION}")
     public List<String> infoList = Arrays.asList(
             "&8-------------------------------",
             "&7Gildia: &c{GUILD} &8[&c{TAG}&8]",
@@ -548,9 +548,9 @@ public class MessageConfiguration extends OkaeriConfig {
     public String adminUserNotMemberOf = "&cTen gracz nie jest czlonkiem tej gildii!";
     public String adminAlreadyLeader = "&cTen gracz jest juz liderem gildii!";
 
-    public String adminNoAdditionalProtectionDateGiven = "&cPodaj date dodatkowej ochrony dla gildii! (W formacie: yyyy/mm/dd hh:mm:ss)";
-    public String adminInvalidAdditionalProtectionDate = "&cTo nie jest poprawna data! Poprawny format to: yyyy/mm/dd hh:mm:ss";
-    public String adminAdditionalProtectionSetSuccessfully = "&aPomyslnie nadano dodatkowa ochrone dla gildii &7{TAG} &ado &7{DATE}";
+    public String adminNoProtectionDateGive = "&cPodaj date ochrony dla gildii! (W formacie: yyyy/mm/dd hh:mm:ss)";
+    public String adminInvalidProtectionDate = "&cTo nie jest poprawna data! Poprawny format to: yyyy/mm/dd hh:mm:ss";
+    public String adminProtectionSetSuccessfully = "&aPomyslnie ustawiono ochrone dla gildii &7{TAG} &ado &7{DATE}";
 
     public String adminGuildHasNoHome = "&cGildia gracza nie ma ustawionej bazy!";
     @Comment("Dostepne zmienne: {ADMIN}")

--- a/src/main/java/net/dzikoysk/funnyguilds/data/database/DatabaseGuild.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/database/DatabaseGuild.java
@@ -129,7 +129,7 @@ public class DatabaseGuild {
         statement.set("lives",    guild.getLives());
         statement.set("born",     guild.getBorn());
         statement.set("validity", guild.getValidity());
-        statement.set("attacked", guild.getAttacked());
+        statement.set("attacked", guild.getProtection()); //TODO: [FG 5.0] attacked -> protection
         statement.set("ban",      guild.getBan());
         statement.set("pvp",      guild.getPvP());
         statement.set("info",     "");

--- a/src/main/java/net/dzikoysk/funnyguilds/data/database/SQLDataModel.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/database/SQLDataModel.java
@@ -72,7 +72,7 @@ public class SQLDataModel implements DataModel {
         tabGuilds.add("born",     SQLType.BIGINT,  true);
         tabGuilds.add("validity", SQLType.BIGINT,  true);
         tabGuilds.add("pvp",      SQLType.BOOLEAN, true);
-        tabGuilds.add("attacked", SQLType.BIGINT);
+        tabGuilds.add("attacked", SQLType.BIGINT); //TODO: [FG 5.0] attacked -> protection
         tabGuilds.add("allies",   SQLType.TEXT);
         tabGuilds.add("enemies",  SQLType.TEXT);
         tabGuilds.add("info",     SQLType.TEXT);

--- a/src/main/java/net/dzikoysk/funnyguilds/data/flat/FlatGuild.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/flat/FlatGuild.java
@@ -180,7 +180,7 @@ public class FlatGuild {
         wrapper.set("enemies", GuildUtils.getNames(guild.getEnemies()));
         wrapper.set("born", guild.getBorn());
         wrapper.set("validity", guild.getValidity());
-        wrapper.set("attacked", guild.getAttacked());
+        wrapper.set("attacked", guild.getProtection()); //TODO: [FG 5.0] attacked -> protection
         wrapper.set("lives", guild.getLives());
         wrapper.set("ban", guild.getBan());
         wrapper.set("pvp", guild.getPvP());

--- a/src/main/java/net/dzikoysk/funnyguilds/data/util/DeserializationUtils.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/util/DeserializationUtils.java
@@ -31,7 +31,7 @@ public final class DeserializationUtils {
         guild.setEnemies((Set<Guild>) values[8]);
         guild.setBorn((long) values[9]);
         guild.setValidity((long) values[10]);
-        guild.setAttacked((long) values[11]);
+        guild.setProtection((long) values[11]);
         guild.setLives((int) values[12]);
         guild.setBan((long) values[13]);
         guild.setDeputies((Set<User>) values[14]);

--- a/src/main/java/net/dzikoysk/funnyguilds/system/war/WarSystem.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/system/war/WarSystem.java
@@ -4,6 +4,7 @@ import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.basic.guild.Guild;
 import net.dzikoysk.funnyguilds.basic.guild.GuildUtils;
 import net.dzikoysk.funnyguilds.basic.user.User;
+import net.dzikoysk.funnyguilds.data.configs.PluginConfiguration;
 import net.dzikoysk.funnyguilds.event.FunnyEvent.EventCause;
 import net.dzikoysk.funnyguilds.event.SimpleEventHandler;
 import net.dzikoysk.funnyguilds.event.guild.GuildDeleteEvent;
@@ -28,6 +29,7 @@ public class WarSystem {
     }
 
     public void attack(Player player, Guild guild) {
+        PluginConfiguration config = FunnyGuilds.getInstance().getPluginConfiguration();
         User user = User.get(player);
 
         if (!user.hasGuild()) {
@@ -46,17 +48,17 @@ public class WarSystem {
             return;
         }
 
-        if (!FunnyGuilds.getInstance().getPluginConfiguration().warEnabled){
+        if (!config.warEnabled){
             WarUtils.message(player, 5);
             return;
         }
         
         if (!guild.canBeAttacked()) {
-            WarUtils.message(player, 2, (guild.getAttacked() + FunnyGuilds.getInstance().getPluginConfiguration().warWait) - System.currentTimeMillis());
+            WarUtils.message(player, 2, (guild.getProtection() + config.warWait) - System.currentTimeMillis());
             return;
         }
         
-        guild.setAttacked(System.currentTimeMillis());
+        guild.setProtection(System.currentTimeMillis() + config.warWait);
         
         if (SimpleEventHandler.handle(new GuildLivesChangeEvent(EventCause.SYSTEM, user, guild, guild.getLives() - 1))) {
             guild.removeLive();


### PR DESCRIPTION
Linked: https://github.com/FunnyGuilds/FunnyGuilds/issues/1487
System ochrony został uproszczony, aby był on bardziej zależny od administratora. Administrator może ustawić dowolną datę wygaśnięcia ochrony gildii nie zależnie od tego, czy gildia posiada już swoją ochronę, inaczej mówiąc, jest w stanie skrócić ochronę.