### PR TITLE
GH-1559 Add "not contains key" check

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserCache.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserCache.java
@@ -62,7 +62,7 @@ public class UserCache {
     }
 
     public double killedBy(User user) {
-        if (user == null) {
+        if (user == null || !damageCaches.containsKey(user)) {
             return 0.0D;
         }
 

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserCache.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserCache.java
@@ -62,11 +62,17 @@ public class UserCache {
     }
 
     public double killedBy(User user) {
-        if (user == null || !damageCaches.containsKey(user)) {
+        if (user == null) {
             return 0.0D;
         }
 
-        return damageCaches.remove(user).getDamage();
+        DamageCache damageCache = damageCaches.remove(user);
+
+        if (damageCache == null) {
+            return 0.0D;
+        }
+
+        return damageCache.getDamage();
     }
 
     public void clearDamage() {


### PR DESCRIPTION
Linked: https://github.com/FunnyGuilds/FunnyGuilds/issues/1559
Wydaje mi się, że to rozwiąże problem. Widzę, że często pojawia się sytuacja, gdzie cache jest czyszczone (chyba z 9x), przez co istnieją pewne wyjątki, w których już nie ma gracza atakującego w cache.