### PR TITLE
Simple rework of user system.

### DIFF
--- a/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
@@ -10,6 +10,7 @@ import net.dzikoysk.funnyguilds.basic.guild.Guild;
 import net.dzikoysk.funnyguilds.basic.guild.GuildUtils;
 import net.dzikoysk.funnyguilds.basic.rank.RankRecalculationTask;
 import net.dzikoysk.funnyguilds.basic.user.User;
+import net.dzikoysk.funnyguilds.basic.user.UserManager;
 import net.dzikoysk.funnyguilds.basic.user.UserUtils;
 import net.dzikoysk.funnyguilds.command.CommandsConfiguration;
 import net.dzikoysk.funnyguilds.concurrency.ConcurrencyManager;
@@ -57,6 +58,7 @@ public class FunnyGuilds extends JavaPlugin {
     private MessageConfiguration   messageConfiguration;
     private ConcurrencyManager     concurrencyManager;
     private DynamicListenerManager dynamicListenerManager;
+    private UserManager            userManager;
 
     private volatile BukkitTask guildValidationTask;
     private volatile BukkitTask tablistBroadcastTask;
@@ -132,6 +134,8 @@ public class FunnyGuilds extends JavaPlugin {
         if (this.forceDisabling) {
             return;
         }
+
+        this.userManager = new UserManager();
 
         try {
             this.dataModel = DataModel.create(this, this.pluginConfiguration.dataModel);
@@ -328,6 +332,10 @@ public class FunnyGuilds extends JavaPlugin {
 
     public DynamicListenerManager getDynamicListenerManager() {
         return this.dynamicListenerManager;
+    }
+
+    public UserManager getUserManager() {
+        return userManager;
     }
 
     public void reloadPluginConfiguration() throws OkaeriException {

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/User.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/User.java
@@ -30,7 +30,7 @@ public class User extends AbstractBasic {
     private       UserBan               ban;
     private final BossBarProvider       bossBarProvider;
 
-    private User(UUID uuid, String name) {
+    User(UUID uuid, String name) {
         this.uuid = uuid;
         this.name = name;
         this.cache = new UserCache(this);
@@ -44,7 +44,7 @@ public class User extends AbstractBasic {
         this(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(Charsets.UTF_8)), name);
     }
 
-    private User(Player player) {
+    User(Player player) {
         this(player.getUniqueId(), player.getName());
     }
 
@@ -218,6 +218,15 @@ public class User extends AbstractBasic {
         return this.name;
     }
 
+    /**
+     * Create new instance of User.
+     *
+     * @param uuid the universally unique identifier of User
+     * @param name the name of User
+     * @return the new instance of User.
+     * @deprecated for removal in the future, in favour of {@link UserManager#create(UUID, String)}
+     */
+    @Deprecated
     public static User create(UUID uuid, String name) {
         Validate.notNull(uuid, "uuid can't be null!");
         Validate.notNull(name, "name can't be null!");
@@ -231,6 +240,14 @@ public class User extends AbstractBasic {
         return user;
     }
 
+    /**
+     * Create new instance of User.
+     *
+     * @param player the instance Player for create a new instance of User
+     * @return the new instance of User.
+     * @deprecated for removal in the future, in favour of {@link UserManager#create(Player)}
+     */
+    @Deprecated
     public static User create(Player player) {
         Validate.notNull(player, "player can't be null!");
 
@@ -241,10 +258,26 @@ public class User extends AbstractBasic {
         return user;
     }
 
+    /**
+     * Gets the user.
+     *
+     * @param uuid the universally unique identifier of User
+     * @return the user
+     * @deprecated for removal in the future, in favour of {@link UserManager#getUser(UUID)}
+     */
+    @Deprecated
     public static User get(UUID uuid) {
         return UserUtils.get(uuid);
     }
 
+    /**
+     * Gets the user.
+     *
+     * @param player the instance Player of User
+     * @return the user
+     * @deprecated for removal in the future, in favour of {@link UserManager#getUser(Player)}
+     */
+    @Deprecated
     public static User get(Player player) {
         if (player.getUniqueId().version() == 2) {
             return new User(player);
@@ -253,10 +286,26 @@ public class User extends AbstractBasic {
         return UserUtils.get(player.getUniqueId());
     }
 
+    /**
+     * Gets the user.
+     *
+     * @param offline the instance OfflinePlayer of User
+     * @return the user
+     * @deprecated for removal in the future, in favour of {@link UserManager#getUser(OfflinePlayer)}
+     */
+    @Deprecated
     public static User get(OfflinePlayer offline) {
         return UserUtils.get(offline.getName());
     }
 
+    /**
+     * Gets the user.
+     *
+     * @param name the name of User
+     * @return the user
+     * @deprecated for removal in the future, in favour of {@link UserManager#getUser(String)}
+     */
+    @Deprecated
     public static User get(String name) {
         return UserUtils.get(name);
     }

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/User.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/User.java
@@ -16,6 +16,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
+import javax.annotation.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.UUID;
 
@@ -265,6 +266,7 @@ public class User extends AbstractBasic {
      * @return the user
      * @deprecated for removal in the future, in favour of {@link UserManager#getUser(UUID)}
      */
+    @Nullable
     @Deprecated
     public static User get(UUID uuid) {
         return UserUtils.get(uuid);
@@ -277,6 +279,7 @@ public class User extends AbstractBasic {
      * @return the user
      * @deprecated for removal in the future, in favour of {@link UserManager#getUser(Player)}
      */
+    @Nullable
     @Deprecated
     public static User get(Player player) {
         if (player.getUniqueId().version() == 2) {
@@ -293,6 +296,7 @@ public class User extends AbstractBasic {
      * @return the user
      * @deprecated for removal in the future, in favour of {@link UserManager#getUser(OfflinePlayer)}
      */
+    @Nullable
     @Deprecated
     public static User get(OfflinePlayer offline) {
         return UserUtils.get(offline.getName());
@@ -305,6 +309,7 @@ public class User extends AbstractBasic {
      * @return the user
      * @deprecated for removal in the future, in favour of {@link UserManager#getUser(String)}
      */
+    @Nullable
     @Deprecated
     public static User get(String name) {
         return UserUtils.get(name);

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserManager.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserManager.java
@@ -6,11 +6,7 @@ import org.apache.commons.lang3.Validate;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.HashSet;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class UserManager {
@@ -18,6 +14,7 @@ public class UserManager {
     private final Map<UUID, User> usersByUuid = new ConcurrentHashMap<>();
     private final Map<String, User> usersByName = new ConcurrentHashMap<>();
 
+    @Deprecated
     private static UserManager instance;
 
     public UserManager() {
@@ -32,50 +29,50 @@ public class UserManager {
         Set<User> users = new HashSet<>();
 
         for (String name : names) {
-            User user = getUser(name);
+            Optional<User> optional = getUser(name);
 
-            if (user == null) {
+            if (!optional.isPresent()) {
                 FunnyGuilds.getPluginLogger().warning("Corrupted user: " + name);
                 continue;
             }
 
-            users.add(user);
+            users.add(optional.get());
         }
 
         return users;
     }
 
-    public User getUser(String nickname) {
+    public Optional<User> getUser(String nickname) {
         return getUser(nickname, false);
     }
 
-    public User getUser(String nickname, boolean ignoreCase) {
+    public Optional<User> getUser(String nickname, boolean ignoreCase) {
         if (ignoreCase) {
             for (Map.Entry<String, User> entry : usersByName.entrySet()) {
                 if (entry.getKey().equalsIgnoreCase(nickname)) {
-                    return entry.getValue();
+                    return Optional.of(entry.getValue());
                 }
             }
 
-            return null;
+            return Optional.empty();
         }
 
-        return usersByName.get(nickname);
+        return Optional.ofNullable(usersByName.get(nickname));
     }
 
-    public User getUser(UUID uuid) {
-        return usersByUuid.get(uuid);
+    public Optional<User> getUser(UUID uuid) {
+        return Optional.ofNullable(usersByUuid.get(uuid));
     }
 
-    public User getUser(Player player) {
+    public Optional<User> getUser(Player player) {
         if (player.getUniqueId().version() == 2) {
-            return new User(player);
+            return Optional.of(new User(player));
         }
 
         return getUser(player.getUniqueId());
     }
 
-    public User getUser(OfflinePlayer offline) {
+    public Optional<User> getUser(OfflinePlayer offline) {
         return getUser(offline.getName());
     }
 
@@ -152,7 +149,15 @@ public class UserManager {
         return usersByUuid.size();
     }
 
+    /**
+     * Gets the user manager.
+     *
+     * @return the user manager
+     * @deprecated for removal in the future, in favour of {@link FunnyGuilds#getUserManager()}
+     */
+    @Deprecated
     public static UserManager getInstance() {
         return instance;
     }
+
 }

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserManager.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserManager.java
@@ -5,13 +5,13 @@ import net.dzikoysk.funnyguilds.basic.rank.RankManager;
 import org.apache.commons.lang3.Validate;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
+import org.panda_lang.utilities.commons.function.Option;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class UserManager {
@@ -34,7 +34,7 @@ public class UserManager {
         Set<User> users = new HashSet<>();
 
         for (String name : names) {
-            Optional<User> optional = getUser(name);
+            Option<User> optional = getUser(name);
 
             if (!optional.isPresent()) {
                 FunnyGuilds.getPluginLogger().warning("Corrupted user: " + name);
@@ -47,37 +47,37 @@ public class UserManager {
         return users;
     }
 
-    public Optional<User> getUser(String nickname) {
+    public Option<User> getUser(String nickname) {
         return getUser(nickname, false);
     }
 
-    public Optional<User> getUser(String nickname, boolean ignoreCase) {
+    public Option<User> getUser(String nickname, boolean ignoreCase) {
         if (ignoreCase) {
             for (Map.Entry<String, User> entry : usersByName.entrySet()) {
                 if (entry.getKey().equalsIgnoreCase(nickname)) {
-                    return Optional.of(entry.getValue());
+                    return Option.of(entry.getValue());
                 }
             }
 
-            return Optional.empty();
+            return Option.none();
         }
 
-        return Optional.ofNullable(usersByName.get(nickname));
+        return Option.of(usersByName.get(nickname));
     }
 
-    public Optional<User> getUser(UUID uuid) {
-        return Optional.ofNullable(usersByUuid.get(uuid));
+    public Option<User> getUser(UUID uuid) {
+        return Option.of(usersByUuid.get(uuid));
     }
 
-    public Optional<User> getUser(Player player) {
+    public Option<User> getUser(Player player) {
         if (player.getUniqueId().version() == 2) {
-            return Optional.of(new User(player));
+            return Option.of(new User(player));
         }
 
         return getUser(player.getUniqueId());
     }
 
-    public Optional<User> getUser(OfflinePlayer offline) {
+    public Option<User> getUser(OfflinePlayer offline) {
         return getUser(offline.getName());
     }
 

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserManager.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserManager.java
@@ -6,7 +6,12 @@ import org.apache.commons.lang3.Validate;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class UserManager {

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserManager.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserManager.java
@@ -1,0 +1,158 @@
+package net.dzikoysk.funnyguilds.basic.user;
+
+import net.dzikoysk.funnyguilds.FunnyGuilds;
+import net.dzikoysk.funnyguilds.basic.rank.RankManager;
+import org.apache.commons.lang3.Validate;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class UserManager {
+
+    private final Map<UUID, User> usersByUuid = new ConcurrentHashMap<>();
+    private final Map<String, User> usersByName = new ConcurrentHashMap<>();
+
+    private static UserManager instance;
+
+    public UserManager() {
+        instance = this;
+    }
+
+    public Set<User> getUsers() {
+        return new HashSet<>(usersByUuid.values());
+    }
+
+    public Set<User> getUsers(Collection<String> names) {
+        Set<User> users = new HashSet<>();
+
+        for (String name : names) {
+            User user = getUser(name);
+
+            if (user == null) {
+                FunnyGuilds.getPluginLogger().warning("Corrupted user: " + name);
+                continue;
+            }
+
+            users.add(user);
+        }
+
+        return users;
+    }
+
+    public User getUser(String nickname) {
+        return getUser(nickname, false);
+    }
+
+    public User getUser(String nickname, boolean ignoreCase) {
+        if (ignoreCase) {
+            for (Map.Entry<String, User> entry : usersByName.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase(nickname)) {
+                    return entry.getValue();
+                }
+            }
+
+            return null;
+        }
+
+        return usersByName.get(nickname);
+    }
+
+    public User getUser(UUID uuid) {
+        return usersByUuid.get(uuid);
+    }
+
+    public User getUser(Player player) {
+        if (player.getUniqueId().version() == 2) {
+            return new User(player);
+        }
+
+        return getUser(player.getUniqueId());
+    }
+
+    public User getUser(OfflinePlayer offline) {
+        return getUser(offline.getName());
+    }
+
+    public User create(UUID uuid, String name) {
+        Validate.notNull(uuid, "uuid can't be null!");
+        Validate.notNull(name, "name can't be null!");
+        Validate.notBlank(name, "name can't be blank!");
+        Validate.isTrue(UserUtils.validateUsername(name), "name is not valid!");
+
+        User user = new User(uuid, name);
+
+        addUser(user);
+        RankManager.getInstance().update(user);
+
+        return user;
+    }
+
+    public User create(Player player) {
+        Validate.notNull(player, "player can't be null!");
+
+        User user = new User(player);
+        addUser(user);
+        RankManager.getInstance().update(user);
+
+        return user;
+    }
+
+    public void addUser(User user) {
+        Validate.notNull(user, "user can't be null!");
+
+        usersByUuid.put(user.getUUID(), user);
+        usersByName.put(user.getName(), user);
+    }
+
+    public void removeUser(User user) {
+        Validate.notNull(user, "user can't be null!");
+
+        usersByUuid.remove(user.getUUID());
+        usersByName.remove(user.getName());
+    }
+
+    public void updateUsername(User user, String newUsername) {
+        Validate.notNull(user, "user can't be null!");
+
+        usersByName.remove(user.getName());
+        usersByName.put(newUsername, user);
+
+        user.setName(newUsername);
+    }
+
+    public boolean playedBefore(String nickname) {
+        return playedBefore(nickname, false);
+    }
+
+    public boolean playedBefore(String nickname, boolean ignoreCase) {
+        if (nickname == null) {
+            return false;
+        }
+
+        if (ignoreCase) {
+            for (String userNickname : usersByName.keySet()) {
+                if (userNickname.equalsIgnoreCase(nickname)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return usersByName.containsKey(nickname);
+    }
+
+    public int usersSize() {
+        return usersByUuid.size();
+    }
+
+    public static UserManager getInstance() {
+        return instance;
+    }
+}

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserUtils.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserUtils.java
@@ -4,7 +4,10 @@ import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.basic.guild.Guild;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
+import java.util.HashSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserUtils.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserUtils.java
@@ -50,7 +50,7 @@ public class UserUtils {
     @Nullable
     @Deprecated
     public static User get(String nickname, boolean ignoreCase) {
-        return UserManager.getInstance().getUser(nickname, ignoreCase).orElse(null);
+        return UserManager.getInstance().getUser(nickname, ignoreCase).getOrNull();
     }
 
     /**
@@ -63,7 +63,7 @@ public class UserUtils {
     @Nullable
     @Deprecated
     public static User get(UUID uuid) {
-        return UserManager.getInstance().getUser(uuid).orElse(null);
+        return UserManager.getInstance().getUser(uuid).getOrNull();
     }
 
     /**

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserUtils.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserUtils.java
@@ -3,6 +3,7 @@ package net.dzikoysk.funnyguilds.basic.user;
 import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.basic.guild.Guild;
 
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ public class UserUtils {
      * @return the user
      * @deprecated for removal in the future, in favour of {@link UserManager#getUser(String)}
      */
+    @Nullable
     @Deprecated
     public static User get(String nickname) {
         return get(nickname, false);
@@ -42,9 +44,10 @@ public class UserUtils {
      * @return the user
      * @deprecated for removal in the future, in favour of {@link UserManager#getUser(String, boolean)}
      */
+    @Nullable
     @Deprecated
     public static User get(String nickname, boolean ignoreCase) {
-        return UserManager.getInstance().getUser(nickname, ignoreCase);
+        return UserManager.getInstance().getUser(nickname, ignoreCase).orElse(null);
     }
 
     /**
@@ -54,9 +57,10 @@ public class UserUtils {
      * @return the user
      * @deprecated for removal in the future, in favour of {@link UserManager#getUser(UUID)}
      */
+    @Nullable
     @Deprecated
     public static User get(UUID uuid) {
-        return UserManager.getInstance().getUser(uuid);
+        return UserManager.getInstance().getUser(uuid).orElse(null);
     }
 
     /**

--- a/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserUtils.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/basic/user/UserUtils.java
@@ -2,10 +2,8 @@ package net.dzikoysk.funnyguilds.basic.user;
 
 import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.basic.guild.Guild;
-import org.apache.commons.lang3.Validate;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -13,85 +11,118 @@ public class UserUtils {
 
     private static final Pattern USERNAME_PATTERN = Pattern.compile("^[A-Za-z0-9_]{3,16}$");
 
-    private final static Map<UUID, User> BY_UUID_USER_COLLECTION = new ConcurrentHashMap<>();
-    private final static Map<String, User> BY_NAME_USER_COLLECTION = new ConcurrentHashMap<>();
-
+    /**
+     * Gets the copied set of users.
+     *
+     * @return set of users
+     * @deprecated for removal in the future, in favour of {@link UserManager#getUsers()}
+     */
+    @Deprecated
     public static Set<User> getUsers() {
-        return new HashSet<>(BY_UUID_USER_COLLECTION.values());
+        return UserManager.getInstance().getUsers();
     }
 
+    /**
+     * Gets the user.
+     *
+     * @param nickname the name of User
+     * @return the user
+     * @deprecated for removal in the future, in favour of {@link UserManager#getUser(String)}
+     */
+    @Deprecated
     public static User get(String nickname) {
         return get(nickname, false);
     }
 
+    /**
+     * Gets the user.
+     *
+     * @param nickname the name of User
+     * @param ignoreCase ignore the case of the nickname
+     * @return the user
+     * @deprecated for removal in the future, in favour of {@link UserManager#getUser(String, boolean)}
+     */
+    @Deprecated
     public static User get(String nickname, boolean ignoreCase) {
-        if (ignoreCase) {
-            for (Map.Entry<String, User> entry : BY_NAME_USER_COLLECTION.entrySet()) {
-                if (entry.getKey().equalsIgnoreCase(nickname)) {
-                    return entry.getValue();
-                }
-            }
-
-            return null;
-        }
-        else {
-            return BY_NAME_USER_COLLECTION.get(nickname);
-        }
+        return UserManager.getInstance().getUser(nickname, ignoreCase);
     }
 
+    /**
+     * Gets the user.
+     *
+     * @param uuid the universally unique identifier of User
+     * @return the user
+     * @deprecated for removal in the future, in favour of {@link UserManager#getUser(UUID)}
+     */
+    @Deprecated
     public static User get(UUID uuid) {
-        return BY_UUID_USER_COLLECTION.get(uuid);
+        return UserManager.getInstance().getUser(uuid);
     }
 
+    /**
+     * Add the user to UserManager.
+     *
+     * @param user User to be appended to UserManager.
+     * @deprecated for removal in the future, in favour of {@link UserManager#addUser(User)}
+     */
+    @Deprecated
     public static void addUser(User user) {
-        Validate.notNull(user, "user can't be null!");
-
-        BY_UUID_USER_COLLECTION.put(user.getUUID(), user);
-        BY_NAME_USER_COLLECTION.put(user.getName(), user);
+        UserManager.getInstance().addUser(user);
     }
 
+    /**
+     * Remove the user from UserManager.
+     *
+     * @param user User to be removed from UserManager, if present
+     * @deprecated for removal in the future, in favour of {@link UserManager#removeUser(User)}
+     */
+    @Deprecated
     public static void removeUser(User user) {
-        Validate.notNull(user, "user can't be null!");
-
-        BY_UUID_USER_COLLECTION.remove(user.getUUID());
-        BY_NAME_USER_COLLECTION.remove(user.getName());
+        UserManager.getInstance().removeUser(user);
     }
 
+    /**
+     * Updates the user's name.
+     *
+     * @param user the user
+     * @param newUsername the new name to be assigned to user
+     * @deprecated for removal in the future, in favour of {@link UserManager#updateUsername(User, String)}
+     */
+    @Deprecated
     public static void updateUsername(User user, String newUsername) {
-        Validate.notNull(user, "user can't be null!");
-
-        BY_NAME_USER_COLLECTION.remove(user.getName());
-        BY_NAME_USER_COLLECTION.put(newUsername, user);
-
-        user.setName(newUsername);
+        UserManager.getInstance().updateUsername(user, newUsername);
     }
 
+    /**
+     * Checks if the player has ever been on the server.
+     *
+     * @param nickname name of player
+     * @return true if the player has played before
+     * @deprecated for removal in the future, in favour of {@link UserManager#playedBefore(String)}
+     */
+    @Deprecated
     public static boolean playedBefore(String nickname) {
         return playedBefore(nickname, false);
     }
 
+    /**
+     * Checks if the player has ever been on the server.
+     *
+     * @param nickname name of player
+     * @param ignoreCase ignore the case of the name
+     * @return true if the player has played before
+     * @deprecated for removal in the future, in favour of {@link UserManager#playedBefore(String, boolean)}
+     */
+    @Deprecated
     public static boolean playedBefore(String nickname, boolean ignoreCase) {
-        if (ignoreCase) {
-            if (nickname != null) {
-                for (String userNickname : BY_NAME_USER_COLLECTION.keySet()) {
-                    if (userNickname.equalsIgnoreCase(nickname)) {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-        else {
-            return nickname != null && BY_NAME_USER_COLLECTION.containsKey(nickname);
-        }
+        return UserManager.getInstance().playedBefore(nickname, ignoreCase);
     }
 
-    public static Set<String> getNames(Collection<User> users) {
+    public static Set<String> getNamesOfUsers(Collection<User> users) {
         return users.stream().map(User::getName).collect(Collectors.toSet());
     }
 
-    public static Set<User> getUsers(Collection<String> names) {
+    public static Set<User> getUsersFromString(Collection<String> names) {
         Set<User> users = new HashSet<>();
 
         for (String name : names) {
@@ -129,8 +160,15 @@ public class UserUtils {
         }
     }
 
+    /**
+     * Gets the number of users.
+     *
+     * @return the number of users
+     * @deprecated for removal in the future, in favour of {@link UserManager#usersSize()}
+     */
+    @Deprecated
     public static int usersSize() {
-        return BY_UUID_USER_COLLECTION.size();
+        return UserManager.getInstance().usersSize();
     }
 
     public static boolean validateUsername(String name) {

--- a/src/main/java/net/dzikoysk/funnyguilds/command/user/InfoCommand.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/command/user/InfoCommand.java
@@ -57,7 +57,7 @@ public final class InfoCommand {
             messageLine = StringUtils.replace(messageLine, "{MEMBERS-ONLINE}", String.valueOf(guild.getOnlineMembers().size()));
             messageLine = StringUtils.replace(messageLine, "{MEMBERS-ALL}", String.valueOf(guild.getMembers().size()));
             messageLine = StringUtils.replace(messageLine, "{MEMBERS}", ChatUtils.toString(UserUtils.getOnlineNames(guild.getMembers()), true));
-            messageLine = StringUtils.replace(messageLine, "{DEPUTIES}", guild.getDeputies().isEmpty() ? "Brak" : ChatUtils.toString(UserUtils.getNames(guild.getDeputies()), true));
+            messageLine = StringUtils.replace(messageLine, "{DEPUTIES}", guild.getDeputies().isEmpty() ? "Brak" : ChatUtils.toString(UserUtils.getNamesOfUsers(guild.getDeputies()), true));
             messageLine = StringUtils.replace(messageLine, "{REGION-SIZE}", config.regionsEnabled ? String.valueOf(guild.getRegion().getSize()) : messages.gRegionSizeNoValue);
             messageLine = StringUtils.replace(messageLine, "{GUILD-PROTECTION}", protectionEndTime < now ? "Brak" : TimeUtils.getDurationBreakdown(protectionEndTime - now));
 

--- a/src/main/java/net/dzikoysk/funnyguilds/data/database/DatabaseGuild.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/database/DatabaseGuild.java
@@ -59,12 +59,12 @@ public class DatabaseGuild {
             
             Set<User> deputies = new HashSet<>();
             if (dp != null && !dp.isEmpty()) {
-                deputies = UserUtils.getUsers(ChatUtils.fromString(dp));
+                deputies = UserUtils.getUsersFromString(ChatUtils.fromString(dp));
             }
 
             Set<User> members = new HashSet<>();
             if (membersString != null && !membersString.equals("")) {
-                members = UserUtils.getUsers(ChatUtils.fromString(membersString));
+                members = UserUtils.getUsersFromString(ChatUtils.fromString(membersString));
             }
 
             if (born == 0) {
@@ -108,8 +108,8 @@ public class DatabaseGuild {
     }
 
     public static void save(Guild guild) {
-        String members = ChatUtils.toString(UserUtils.getNames(guild.getMembers()), false);
-        String deputies = ChatUtils.toString(UserUtils.getNames(guild.getDeputies()), false);
+        String members = ChatUtils.toString(UserUtils.getNamesOfUsers(guild.getMembers()), false);
+        String deputies = ChatUtils.toString(UserUtils.getNamesOfUsers(guild.getDeputies()), false);
         String allies = ChatUtils.toString(GuildUtils.getNames(guild.getAllies()), false);
         String enemies = ChatUtils.toString(GuildUtils.getNames(guild.getEnemies()), false);
         SQLNamedStatement statement = SQLBasicUtils.getInsert(SQLDataModel.tabGuilds);

--- a/src/main/java/net/dzikoysk/funnyguilds/data/flat/FlatGuild.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/data/flat/FlatGuild.java
@@ -88,7 +88,7 @@ public class FlatGuild {
 
         Set<User> deputies = ConcurrentHashMap.newKeySet(1);
         if (deputyName != null && !deputyName.isEmpty()) {
-            deputies = UserUtils.getUsers(ChatUtils.fromString(deputyName));
+            deputies = UserUtils.getUsersFromString(ChatUtils.fromString(deputyName));
         }
 
         Location home = null;
@@ -106,7 +106,7 @@ public class FlatGuild {
             memberNames.add(ownerName);
         }
 
-        Set<User> members = UserUtils.getUsers(memberNames);
+        Set<User> members = UserUtils.getUsersFromString(memberNames);
         Set<Guild> allies = loadGuilds(allyNames);
         Set<Guild> enemies = loadGuilds(enemyNames);
 
@@ -173,7 +173,7 @@ public class FlatGuild {
         wrapper.set("tag", guild.getTag());
         wrapper.set("owner", guild.getOwner().getName());
         wrapper.set("home", LocationUtils.toString(guild.getHome()));
-        wrapper.set("members", UserUtils.getNames(guild.getMembers()));
+        wrapper.set("members", UserUtils.getNamesOfUsers(guild.getMembers()));
         wrapper.set("region", RegionUtils.toString(guild.getRegion()));
         wrapper.set("regions", null);
         wrapper.set("allies", GuildUtils.getNames(guild.getAllies()));
@@ -184,7 +184,7 @@ public class FlatGuild {
         wrapper.set("lives", guild.getLives());
         wrapper.set("ban", guild.getBan());
         wrapper.set("pvp", guild.getPvP());
-        wrapper.set("deputy", ChatUtils.toString(UserUtils.getNames(guild.getDeputies()), false));
+        wrapper.set("deputy", ChatUtils.toString(UserUtils.getNamesOfUsers(guild.getDeputies()), false));
 
         wrapper.save();
         return true;

--- a/src/main/java/net/dzikoysk/funnyguilds/element/tablist/variable/DefaultTablistVariables.java
+++ b/src/main/java/net/dzikoysk/funnyguilds/element/tablist/variable/DefaultTablistVariables.java
@@ -148,7 +148,7 @@ public final class DefaultTablistVariables {
         FUNNY_VARIABLES.put("g-deputies", GuildDependentTablistVariable.ofGuild("G-DEPUTIES",
                 guild -> guild.getDeputies().isEmpty()
                         ? messages.gDeputiesNoValue
-                        : ChatUtils.toString(UserUtils.getNames(guild.getDeputies()), false),
+                        : ChatUtils.toString(UserUtils.getNamesOfUsers(guild.getDeputies()), false),
                 user -> messages.gDeputiesNoValue));
 
         FUNNY_VARIABLES.put("g-deputy", GuildDependentTablistVariable.ofGuild("G-DEPUTY",


### PR DESCRIPTION
PR ma zmienić system przetrzymywania userów (Od teraz są przetrzymywani w instancji klasy UserManager). Wszystkie wcześniejsze metody w klasie User i UserUtils zostały oznaczone adnotacją `@Deprecated` i dodatkowo opisane, jakich metod powinno się używać w zastępstwie.
Np.:
![image](https://user-images.githubusercontent.com/49173834/121569200-d23e6200-ca20-11eb-9fff-fdbe2386f840.png)
Wiem, że w FG nie robimy dokumentacji. Jeśli to możliwe fajnie jakby była ona dostępna na czas istnienia tych metod.