### PR TITLE
Enhance config with Duration instead of inconsistent long representations

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -10,9 +10,9 @@ dependencies {
     implementation "org.panda-lang:panda-utilities:0.5.0-alpha"
 
     // okaeri config library
-    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:3.0.0"
-    implementation "eu.okaeri:okaeri-configs-serdes-commons:3.0.0"
-    implementation "eu.okaeri:okaeri-configs-validator-okaeri:3.0.0"
+    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:3.1.0"
+    implementation "eu.okaeri:okaeri-configs-serdes-commons:3.1.0"
+    implementation "eu.okaeri:okaeri-configs-validator-okaeri:3.1.0"
 
     // general stuff
     implementation "com.zaxxer:HikariCP:4.0.3"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -10,8 +10,9 @@ dependencies {
     implementation "org.panda-lang:panda-utilities:0.5.0-alpha"
 
     // okaeri config library
-    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:2.7.20"
-    implementation "eu.okaeri:okaeri-configs-validator-okaeri:2.7.20"
+    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:3.0.0"
+    implementation "eu.okaeri:okaeri-configs-serdes-commons:3.0.0"
+    implementation "eu.okaeri:okaeri-configs-validator-okaeri:3.0.0"
 
     // general stuff
     implementation "com.zaxxer:HikariCP:4.0.3"

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
@@ -3,6 +3,7 @@ package net.dzikoysk.funnyguilds;
 import eu.okaeri.configs.ConfigManager;
 import eu.okaeri.configs.exception.OkaeriException;
 import eu.okaeri.configs.serdes.SimpleObjectTransformer;
+import eu.okaeri.configs.serdes.commons.SerdesCommons;
 import eu.okaeri.configs.validator.okaeri.OkaeriValidator;
 import eu.okaeri.configs.yaml.bukkit.YamlBukkitConfigurer;
 import net.dzikoysk.funnycommands.FunnyCommands;
@@ -141,7 +142,7 @@ public class FunnyGuilds extends JavaPlugin {
                 it.load(true);
             });
             this.pluginConfiguration = ConfigManager.create(PluginConfiguration.class, (it) -> {
-                it.withConfigurer(new OkaeriValidator(new YamlBukkitConfigurer(), true));
+                it.withConfigurer(new OkaeriValidator(new YamlBukkitConfigurer(), true), new SerdesCommons());
                 it.withBindFile(this.pluginConfigurationFile);
                 it.saveDefaults();
                 it.load(true);

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/basic/guild/Guild.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/basic/guild/Guild.java
@@ -10,6 +10,7 @@ import net.dzikoysk.funnyguilds.basic.user.UserUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
@@ -247,7 +248,7 @@ public class Guild extends AbstractBasic {
 
     public void setValidity(long l) {
         if (l == this.born) {
-            this.validity = System.currentTimeMillis() + FunnyGuilds.getInstance().getPluginConfiguration().validityStart;
+            this.validity = Instant.now().plus(FunnyGuilds.getInstance().getPluginConfiguration().validityStart).toEpochMilli();
         }
         else {
             this.validity = l;
@@ -301,7 +302,7 @@ public class Guild extends AbstractBasic {
 
     public boolean isValid() {
         if (this.validity == this.born || this.validity == 0) {
-            this.validity = System.currentTimeMillis() + FunnyGuilds.getInstance().getPluginConfiguration().validityStart;
+            this.validity = Instant.now().plus(FunnyGuilds.getInstance().getPluginConfiguration().validityStart).toEpochMilli();
             this.markChanged();
         }
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/command/user/CreateCommand.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/command/user/CreateCommand.java
@@ -34,6 +34,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import panda.utilities.text.Formatter;
 
+import java.time.Instant;
 import java.util.List;
 
 import static net.dzikoysk.funnyguilds.command.DefaultValidation.when;
@@ -150,8 +151,8 @@ public final class CreateCommand {
         guild.setOwner(user);
         guild.setLives(config.warLives);
         guild.setBorn(System.currentTimeMillis());
-        guild.setValidity(System.currentTimeMillis() + config.validityStart);
-        guild.setProtection(System.currentTimeMillis() + config.warProtection);
+        guild.setValidity(Instant.now().plus(config.validityStart).toEpochMilli());
+        guild.setProtection(Instant.now().plus(config.warProtection).toEpochMilli());
         guild.setPvP(config.damageGuild);
         guild.setHome(guildLocation);
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/concurrency/requests/FunnybinRequest.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/concurrency/requests/FunnybinRequest.java
@@ -2,6 +2,7 @@ package net.dzikoysk.funnyguilds.concurrency.requests;
 
 import com.google.common.io.Files;
 import eu.okaeri.configs.ConfigManager;
+import eu.okaeri.configs.serdes.commons.SerdesCommons;
 import eu.okaeri.configs.yaml.bukkit.YamlBukkitConfigurer;
 import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.concurrency.util.DefaultConcurrencyRequest;
@@ -55,7 +56,7 @@ public final class FunnybinRequest extends DefaultConcurrencyRequest {
                 type = PasteType.CONFIG;
 
                 PluginConfiguration config = ConfigManager.create(PluginConfiguration.class, (it) -> {
-                    it.withConfigurer(new YamlBukkitConfigurer());
+                    it.withConfigurer(new YamlBukkitConfigurer(), new SerdesCommons());
                     it.withBindFile(FunnyGuilds.getInstance().getPluginConfigurationFile());
                     it.load();
                 });

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/data/configs/PluginConfiguration.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/data/configs/PluginConfiguration.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.annotation.*;
 import eu.okaeri.configs.exception.OkaeriException;
+import eu.okaeri.configs.serdes.commons.duration.DurationSpec;
 import eu.okaeri.validator.annotation.*;
 import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.basic.guild.GuildRegex;
@@ -14,7 +15,6 @@ import net.dzikoysk.funnyguilds.element.notification.bossbar.provider.BossBarOpt
 import net.dzikoysk.funnyguilds.util.Cooldown;
 import net.dzikoysk.funnyguilds.util.IntegerRange;
 import net.dzikoysk.funnyguilds.util.commons.ChatUtils;
-import net.dzikoysk.funnyguilds.util.commons.TimeUtils;
 import net.dzikoysk.funnyguilds.util.commons.bukkit.ItemBuilder;
 import net.dzikoysk.funnyguilds.util.commons.bukkit.ItemUtils;
 import net.dzikoysk.funnyguilds.util.commons.bukkit.MaterialUtils;
@@ -27,8 +27,10 @@ import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -404,13 +406,13 @@ public class PluginConfiguration extends OkaeriConfig {
     @Comment("Mozliwosc teleportacji do gildii")
     public boolean baseEnable = true;
 
-    @Min(0)
+    @PositiveOrZero
     @Comment("Czas oczekiwania na teleportacje, w sekundach")
-    public int baseDelay = 5;
+    public Duration baseDelay = Duration.ofSeconds(5);
 
-    @Min(0)
+    @PositiveOrZero
     @Comment("Czas oczekiwania na teleportacje, w sekundach, dla graczy posiadajacych uprawnienie funnyguilds.vip.baseTeleportTime")
-    public int baseDelayVip = 3;
+    public Duration baseDelayVip = Duration.ofSeconds(3);
 
     @Comment("Koszt teleportacji do gildii. Jezeli teleportacja ma byc darmowa, wystarczy wpisac: base-items: []")
     @CustomKey("base-items")
@@ -448,9 +450,9 @@ public class PluginConfiguration extends OkaeriConfig {
     @Comment("Minimalna odleglosc miedzy terenami gildii")
     public int regionMinDistance = 10;
 
-    @Min(1)
+    @Positive
     @Comment("Czas wyswietlania powiadomienia na pasku powiadomien, w sekundach")
-    public int regionNotificationTime = 15;
+    public Duration regionNotificationTime = Duration.ofSeconds(15);
 
     @Min(1)
     @Comment("Co ile moze byc wywolywany pasek powiadomien przez jednego gracza, w sekundach")
@@ -529,17 +531,17 @@ public class PluginConfiguration extends OkaeriConfig {
     @Comment("Ile zyc ma gildia")
     public int warLives = 3;
 
+    @PositiveOrZero
+    @DurationSpec(fallbackUnit = ChronoUnit.HOURS)
     @Comment("Po jakim czasie od zalozenia mozna zaatakowac gildie")
     @CustomKey("war-protection")
-    public String warProtection_ = "24h";
-    @Exclude
-    public long warProtection;
+    public Duration warProtection = Duration.ofHours(24);
 
+    @PositiveOrZero
+    @DurationSpec(fallbackUnit = ChronoUnit.HOURS)
     @Comment("Ile czasu trzeba czekac do nastepnego ataku na gildie")
     @CustomKey("war-wait")
-    public String warWait_ = "24h";
-    @Exclude
-    public long warWait;
+    public Duration warWait = Duration.ofHours(24);
 
     @Comment("Czy gildia podczas okresu ochronnego ma posiadac ochrone przeciw TNT")
     public boolean warTntProtection = true;
@@ -547,25 +549,23 @@ public class PluginConfiguration extends OkaeriConfig {
     @Comment("Czy zwierzeta na terenie gildii maja byc chronione przed osobami spoza gildii")
     public boolean animalsProtection = false;
 
+    @Positive
+    @DurationSpec(fallbackUnit = ChronoUnit.DAYS)
     @Comment("Jaka waznosc ma gildia po jej zalozeniu")
     @CustomKey("validity-start")
-    public String validityStart_ = "14d";
+    public Duration validityStart = Duration.ofDays(14);
 
-    @Exclude
-    public long validityStart;
-
+    @Positive
+    @DurationSpec(fallbackUnit = ChronoUnit.DAYS)
     @Comment("Ile czasu dodaje przedluzenie gildii")
     @CustomKey("validity-time")
-    public String validityTime_ = "14d";
+    public Duration validityTime = Duration.ofDays(14);
 
-    @Exclude
-    public long validityTime;
-
+    @PositiveOrZero
+    @DurationSpec(fallbackUnit = ChronoUnit.DAYS)
     @Comment("Ile dni przed koncem wygasania mozna przedluzyc gildie. Wpisz 0, jezeli funkcja ma byc wylaczona")
     @CustomKey("validity-when")
-    public String validityWhen_ = "14d";
-    @Exclude
-    public long validityWhen;
+    public Duration validityWhen = Duration.ofDays(14);
 
     @Comment("Koszt przedluzenia gildii")
     @CustomKey("validity-items")
@@ -656,14 +656,14 @@ public class PluginConfiguration extends OkaeriConfig {
     @Exclude
     public Map<IntegerRange, Integer> eloConstants;
 
-    @DecimalMin("0.00001")
+    @Positive
     @Comment("Sekcja uzywana TYLKO jesli wybranym rank-system jest ELO!")
     @Comment("Dzielnik obliczen rankingowych ELO - im mniejszy, tym wieksze zmiany rankingu")
     @Comment("Dzielnik powinien byc liczba dodatnia, niezerowa")
     @CustomKey("elo-divider")
     public double eloDivider = 400.0D;
 
-    @DecimalMin("0.00001")
+    @Positive
     @Comment("Sekcja uzywana TYLKO jesli wybranym rank-system jest ELO!")
     @Comment("Wykladnik potegi obliczen rankingowych ELO - im mniejszy, tym wieksze zmiany rankingu")
     @Comment("Wykladnik powinien byc liczba dodatnia, niezerowa")
@@ -1382,13 +1382,6 @@ public class PluginConfiguration extends OkaeriConfig {
         this.rankResetItems = loadItemStackList(this.rankResetItems_);
 
         this.firstGuildRewards = loadItemStackList(this.firstGuildRewards_);
-
-        this.warProtection = TimeUtils.parseTime(this.warProtection_);
-        this.warWait = TimeUtils.parseTime(this.warWait_);
-
-        this.validityStart = TimeUtils.parseTime(this.validityStart_);
-        this.validityTime = TimeUtils.parseTime(this.validityTime_);
-        this.validityWhen = TimeUtils.parseTime(this.validityWhen_);
 
         this.validityItems = this.loadItemStackList(this.validityItems_);
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/data/database/DatabaseGuild.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/data/database/DatabaseGuild.java
@@ -15,6 +15,7 @@ import net.dzikoysk.funnyguilds.util.commons.ChatUtils;
 import net.dzikoysk.funnyguilds.util.commons.bukkit.LocationUtils;
 
 import java.sql.ResultSet;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -72,7 +73,7 @@ public class DatabaseGuild {
             }
             
             if (validity == 0) {
-                validity = System.currentTimeMillis() + FunnyGuilds.getInstance().getPluginConfiguration().validityStart;
+                validity = Instant.now().plus(FunnyGuilds.getInstance().getPluginConfiguration().validityStart).toEpochMilli();
             }
             
             if (lives == 0) {

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/data/flat/FlatGuild.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/data/flat/FlatGuild.java
@@ -16,6 +16,7 @@ import net.dzikoysk.funnyguilds.util.commons.bukkit.LocationUtils;
 import org.bukkit.Location;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -115,7 +116,7 @@ public class FlatGuild {
         }
 
         if (validity == 0) {
-            validity = System.currentTimeMillis() + configuration.validityStart;
+            validity = Instant.now().plus(configuration.validityStart).toEpochMilli();
         }
 
         if (lives == 0) {

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/element/notification/bossbar/provider/BossBarProvider.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/element/notification/bossbar/provider/BossBarProvider.java
@@ -5,7 +5,14 @@ import net.dzikoysk.funnyguilds.element.notification.bossbar.provider.v1_8.BossB
 import net.dzikoysk.funnyguilds.util.nms.Reflections;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Duration;
+
 public interface BossBarProvider {
+
+    default void sendNotification(String text, @Nullable BossBarOptions options, Duration timeout) {
+        int timeoutSeconds = Math.toIntExact(timeout.getSeconds());
+        this.sendNotification(text, options, (timeoutSeconds > 0) ? timeoutSeconds : 1);
+    }
 
     void sendNotification(String text, @Nullable BossBarOptions options, int timeout);
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/system/war/WarSystem.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/system/war/WarSystem.java
@@ -12,6 +12,10 @@ import net.dzikoysk.funnyguilds.event.guild.GuildLivesChangeEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 public class WarSystem {
 
     private static WarSystem instance;
@@ -54,11 +58,11 @@ public class WarSystem {
         }
         
         if (!guild.canBeAttacked()) {
-            WarUtils.message(player, 2, (guild.getProtection() + config.warWait) - System.currentTimeMillis());
+            WarUtils.message(player, 2, Duration.between(Instant.now(), Instant.ofEpochMilli(guild.getProtection()).plus(config.warWait)).get(ChronoUnit.MILLIS));
             return;
         }
-        
-        guild.setProtection(System.currentTimeMillis() + config.warWait);
+
+        guild.setProtection(Instant.now().plus(config.warWait).toEpochMilli());
         
         if (SimpleEventHandler.handle(new GuildLivesChangeEvent(EventCause.SYSTEM, user, guild, guild.getLives() - 1))) {
             guild.removeLive();


### PR DESCRIPTION
## Introducing Duration Update

- replaces duration fields with the [proper Duration type](https://github.com/OkaeriPoland/okaeri-configs/blob/master/serdes-commons/src/main/java/eu/okaeri/configs/serdes/commons/duration/DurationTransformer.java)
- adapts codebase to the new fields
- removes next chunk of dirty parsing in the load method
- enhances config with more validation annotations
- updates `okaeri-configs` to `3.1.0`


## Compatibility

Fully compatible with minor exceptions: some fields with weird values like "-123123" as duration may not pass new validation and would require manual change to meet current standard. Most users should not be affected.

Third party changes from `okaeri-configs` do not affect current code base, but may affect other plugins accessing FunnyGuild's configuration directly. This is also true for field changes from this PR.


## Config changes

Will be applied at the first startup with the new version. The previous variant is still supported.

`base-delay: 5` -> `base-delay: 5s`
`base-delay-vip: 3` -> `base-delay-vip: 3s`
`region-notification-time: 15` -> `region-notification-time: 15s`
