### PR TITLE
Correct HolographicDisplays hook

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/HookManager.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/HookManager.java
@@ -13,6 +13,7 @@ import net.dzikoysk.funnyguilds.feature.hooks.worldguard.WorldGuard6Hook;
 import net.dzikoysk.funnyguilds.feature.hooks.worldguard.WorldGuard7Hook;
 import net.dzikoysk.funnyguilds.feature.hooks.worldguard.WorldGuardHook;
 import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
 import panda.std.Option;
 import panda.std.stream.PandaStream;
 
@@ -81,7 +82,8 @@ public class HookManager {
             return Option.none();
         }
 
-        if (Bukkit.getPluginManager().getPlugin(pluginName) == null) {
+        Plugin hookPlugin = Bukkit.getPluginManager().getPlugin(pluginName);
+        if (hookPlugin == null || !hookPlugin.isEnabled()) {
             if (notifyIfMissing) {
                 FunnyGuilds.getPluginLogger().info(pluginName + " plugin could not be found, some features may not be available");
             }

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: net.dzikoysk.funnyguilds.FunnyGuilds
 version: '@funnyGuildsVersion@ Tribute-@funnyGuildsCommit@'
 author: 'FunnyGuilds Team'
 website: https://github.com/FunnyGuilds
-softdepend: [WorldEdit, WorldGuard, Vault, PlaceholderAPI, FunnyTab, BungeeTabListPlus, MVdWPlaceholderAPI]
+softdepend: [WorldEdit, WorldGuard, Vault, PlaceholderAPI, FunnyTab, BungeeTabListPlus, MVdWPlaceholderAPI, HolographicDisplays]
 api-version: 1.13
 
 permissions:


### PR DESCRIPTION
Because of no softdepend - HolographicDisplays could be enabled after FG, and if it encountered an error - HD could disable itself, but FG would still use the initialized hook. Now - all hook plugins need to be fully enabled before trying to hook into them.