### PR TITLE
Fix possible iteration on null Set

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/data/flat/FlatGuild.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/data/flat/FlatGuild.java
@@ -204,7 +204,7 @@ public class FlatGuild {
             return (Set<String>) collection;
         }
 
-        return null;
+        return new HashSet<>();
     }
 
 }


### PR DESCRIPTION
If an empty Set was loaded from .yml guild file - the `loadSet()` method returned a null. However the `findByNames()` method assumed that the given Set parameter is not null.

Example guild file: https://pastebin.com/PfgUQFmT
Example error: https://pastebin.com/1zA2zWDU