### PR TITLE
Do not send player list header and footer if they are both empty

### DIFF
--- a/nms/v1_10R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_10R1/playerlist/V1_10R1PlayerList.java
+++ b/nms/v1_10R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_10R1/playerlist/V1_10R1PlayerList.java
@@ -96,20 +96,25 @@ public class V1_10R1PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromString(header, true)[0];
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromString(header, true)[0];
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromString(footer, true)[0];
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent);
+                FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromString(footer, true)[0];
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent);
-            FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);

--- a/nms/v1_11R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_11R1/playerlist/V1_11R1PlayerList.java
+++ b/nms/v1_11R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_11R1/playerlist/V1_11R1PlayerList.java
@@ -96,20 +96,25 @@ public class V1_11R1PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromString(header, true)[0];
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromString(header, true)[0];
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromString(footer, true)[0];
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent);
+                FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromString(footer, true)[0];
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent);
-            FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);

--- a/nms/v1_12R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_12R1/playerlist/V1_12R1PlayerList.java
+++ b/nms/v1_12R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_12R1/playerlist/V1_12R1PlayerList.java
@@ -100,21 +100,26 @@ public class V1_12R1PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromString(header, true)[0];
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromString(header, true)[0];
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromString(footer, true)[0];
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
+                HEADER_ACCESSOR.set(headerFooterPacket, headerComponent);
+                FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromString(footer, true)[0];
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
-            HEADER_ACCESSOR.set(headerFooterPacket, headerComponent);
-            FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);

--- a/nms/v1_13R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_13R2/playerlist/V1_13R2PlayerList.java
+++ b/nms/v1_13R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_13R2/playerlist/V1_13R2PlayerList.java
@@ -92,21 +92,26 @@ public class V1_13R2PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
+                headerFooterPacket.header = headerComponent;
+                headerFooterPacket.footer = footerComponent;
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
-            headerFooterPacket.header = headerComponent;
-            headerFooterPacket.footer = footerComponent;
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);

--- a/nms/v1_14R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_14R1/playerlist/V1_14R1PlayerList.java
+++ b/nms/v1_14R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_14R1/playerlist/V1_14R1PlayerList.java
@@ -92,21 +92,26 @@ public class V1_14R1PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
+                headerFooterPacket.header = headerComponent;
+                headerFooterPacket.footer = footerComponent;
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
-            headerFooterPacket.header = headerComponent;
-            headerFooterPacket.footer = footerComponent;
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);

--- a/nms/v1_15R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_15R1/playerlist/V1_15R1PlayerList.java
+++ b/nms/v1_15R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_15R1/playerlist/V1_15R1PlayerList.java
@@ -92,21 +92,26 @@ public class V1_15R1PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
+                headerFooterPacket.header = headerComponent;
+                headerFooterPacket.footer = footerComponent;
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
-            headerFooterPacket.header = headerComponent;
-            headerFooterPacket.footer = footerComponent;
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);

--- a/nms/v1_16R3/src/main/java/net/dzikoysk/funnyguilds/nms/v1_16R3/playerlist/V1_16R3PlayerList.java
+++ b/nms/v1_16R3/src/main/java/net/dzikoysk/funnyguilds/nms/v1_16R3/playerlist/V1_16R3PlayerList.java
@@ -92,21 +92,26 @@ public class V1_16R3PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
+                headerFooterPacket.header = headerComponent;
+                headerFooterPacket.footer = footerComponent;
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter();
-            headerFooterPacket.header = headerComponent;
-            headerFooterPacket.footer = footerComponent;
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);

--- a/nms/v1_17R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_17R1/playerlist/V1_17R1PlayerList.java
+++ b/nms/v1_17R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_17R1/playerlist/V1_17R1PlayerList.java
@@ -77,19 +77,24 @@ public class V1_17R1PlayerList implements PlayerList {
             updatePlayerPacket.b().addAll(updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent, footerComponent);
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent, footerComponent);
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().b.sendPacket(packet);

--- a/nms/v1_18R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_18R1/playerlist/V1_18R1PlayerList.java
+++ b/nms/v1_18R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_18R1/playerlist/V1_18R1PlayerList.java
@@ -77,19 +77,24 @@ public class V1_18R1PlayerList implements PlayerList {
             updatePlayerPacket.b().addAll(updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromStringOrNull(header, true);
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent, footerComponent);
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromStringOrNull(footer, true);
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent, footerComponent);
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().b.a(packet);

--- a/nms/v1_8R3/src/main/java/net/dzikoysk/funnyguilds/nms/v1_8R3/playerlist/V1_8R3PlayerList.java
+++ b/nms/v1_8R3/src/main/java/net/dzikoysk/funnyguilds/nms/v1_8R3/playerlist/V1_8R3PlayerList.java
@@ -95,20 +95,25 @@ public class V1_8R3PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromString(header, true)[0];
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromString(header, true)[0];
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromString(footer, true)[0];
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent);
+                FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromString(footer, true)[0];
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent);
-            FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);

--- a/nms/v1_9R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_9R2/playerlist/V1_9R2PlayerList.java
+++ b/nms/v1_9R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_9R2/playerlist/V1_9R2PlayerList.java
@@ -96,20 +96,25 @@ public class V1_9R2PlayerList implements PlayerList {
             PLAYER_INFO_DATA_ACCESSOR.set(updatePlayerPacket, updatePlayerList);
             packets.add(updatePlayerPacket);
 
-            IChatBaseComponent headerComponent = EMPTY_COMPONENT;
-            IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+            boolean headerNotEmpty = !header.isEmpty();
+            boolean footerNotEmpty = !footer.isEmpty();
 
-            if (!header.isEmpty()) {
-                headerComponent = CraftChatMessage.fromString(header, true)[0];
+            if (headerNotEmpty || footerNotEmpty) {
+                IChatBaseComponent headerComponent = EMPTY_COMPONENT;
+                IChatBaseComponent footerComponent = EMPTY_COMPONENT;
+
+                if (headerNotEmpty) {
+                    headerComponent = CraftChatMessage.fromString(header, true)[0];
+                }
+
+                if (footerNotEmpty) {
+                    footerComponent = CraftChatMessage.fromString(footer, true)[0];
+                }
+
+                PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent);
+                FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
+                packets.add(headerFooterPacket);
             }
-
-            if (!footer.isEmpty()) {
-                footerComponent = CraftChatMessage.fromString(footer, true)[0];
-            }
-
-            PacketPlayOutPlayerListHeaderFooter headerFooterPacket = new PacketPlayOutPlayerListHeaderFooter(headerComponent);
-            FOOTER_ACCESSOR.set(headerFooterPacket, footerComponent);
-            packets.add(headerFooterPacket);
 
             for (Packet<?> packet : packets) {
                 ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);


### PR DESCRIPTION
Before migration to modules, player list implementation wouldn't send
header and footer if they were an empty strings.

Current behavior causes flickering when there is something else on the
server that is sending header/footer packets and our player list is in use.

Thus, send player list header and footer only if they are defined to be empty
to prevent this issue from occurring.