### PR TITLE
Fix empty region option get, remove deprecated uses of UserUtils

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/data/database/DatabaseGuild.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/data/database/DatabaseGuild.java
@@ -13,15 +13,15 @@ import net.dzikoysk.funnyguilds.data.database.element.SQLNamedStatement;
 import net.dzikoysk.funnyguilds.data.database.element.SQLTable;
 import net.dzikoysk.funnyguilds.data.util.DeserializationUtils;
 import net.dzikoysk.funnyguilds.guild.Guild;
+import net.dzikoysk.funnyguilds.guild.Region;
 import net.dzikoysk.funnyguilds.guild.RegionUtils;
 import net.dzikoysk.funnyguilds.shared.bukkit.ChatUtils;
 import net.dzikoysk.funnyguilds.shared.bukkit.LocationUtils;
 import net.dzikoysk.funnyguilds.user.User;
 import net.dzikoysk.funnyguilds.user.UserManager;
-import net.dzikoysk.funnyguilds.user.UserUtils;
 import panda.std.Option;
 
-public class DatabaseGuild {
+public final class DatabaseGuild {
 
     public static Guild deserialize(ResultSet rs) {
         if (rs == null) {
@@ -61,22 +61,19 @@ public class DatabaseGuild {
             }
 
             Option<User> ownerOption = userManager.findByName(os);
-
             if (ownerOption.isEmpty()) {
                 FunnyGuilds.getPluginLogger().error("Cannot deserialize guild! Caused by: owner (user instance) doesn't exist");
                 return null;
             }
 
-            User owner = ownerOption.get();
-
             Set<User> deputies = new HashSet<>();
             if (dp != null && !dp.isEmpty()) {
-                deputies = UserUtils.getUsersFromString(ChatUtils.fromString(dp));
+                deputies = userManager.findByNames(ChatUtils.fromString(dp));
             }
 
             Set<User> members = new HashSet<>();
-            if (membersString != null && !membersString.equals("")) {
-                members = UserUtils.getUsersFromString(ChatUtils.fromString(membersString));
+            if (membersString != null && !membersString.isEmpty()) {
+                members = userManager.findByNames(ChatUtils.fromString(membersString));
             }
 
             if (born == 0) {
@@ -96,9 +93,9 @@ public class DatabaseGuild {
             values[0] = uuid;
             values[1] = name;
             values[2] = tag;
-            values[3] = owner;
+            values[3] = ownerOption.get();
             values[4] = LocationUtils.parseLocation(home);
-            values[5] = plugin.getRegionManager().findByName(regionName).getOrNull();
+            values[5] = plugin.getRegionManager().findByName(regionName).orElseGet((Region) null);
             values[6] = members;
             values[7] = Sets.newHashSet();
             values[8] = Sets.newHashSet();

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/user/UserUtils.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/user/UserUtils.java
@@ -2,11 +2,9 @@ package net.dzikoysk.funnyguilds.user;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import net.dzikoysk.funnyguilds.FunnyGuilds;
 import org.jetbrains.annotations.ApiStatus;
@@ -15,6 +13,9 @@ public final class UserUtils {
 
     private static final Pattern USERNAME_PATTERN = Pattern.compile("^[A-Za-z0-9_]{3,16}$");
     private static final Pattern UUID_PATTERN = Pattern.compile("^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$");
+
+    private UserUtils() {
+    }
 
     /**
      * Gets the copied set of users.


### PR DESCRIPTION
Fix error thrown when trying to get a value from region option, despite regions being disabled:

```
[18:12:20] [Server thread/INFO]: [FunnyGuilds] Regions are disabled and thus - not loaded
[18:12:20] [Server thread/ERROR]: [FunnyGuilds] 
[18:12:20] [Server thread/ERROR]: [FunnyGuilds] Could not load data from database
[18:12:20] [Server thread/ERROR]: [FunnyGuilds] 
[18:12:20] [Server thread/ERROR]: [FunnyGuilds] java.util.NoSuchElementException: Value is not defined
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at panda.std.Option.get(Option.java:228)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.dzikoysk.funnyguilds.data.flat.FlatGuild.deserialize(FlatGuild.java:85)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.dzikoysk.funnyguilds.data.flat.FlatDataModel.loadGuilds(FlatDataModel.java:281)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.dzikoysk.funnyguilds.data.flat.FlatDataModel.load(FlatDataModel.java:88)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.dzikoysk.funnyguilds.FunnyGuilds.onEnable(FunnyGuilds.java:201)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:321)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:332)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:407)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at org.bukkit.craftbukkit.v1_8_R3.CraftServer.loadPlugin(CraftServer.java:359)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at org.bukkit.craftbukkit.v1_8_R3.CraftServer.enablePlugins(CraftServer.java:318)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.minecraft.server.v1_8_R3.MinecraftServer.s(MinecraftServer.java:408)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.minecraft.server.v1_8_R3.MinecraftServer.k(MinecraftServer.java:372)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.minecraft.server.v1_8_R3.MinecraftServer.a(MinecraftServer.java:327)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.minecraft.server.v1_8_R3.DedicatedServer.init(DedicatedServer.java:267)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:563)
[18:12:20] [Server thread/ERROR]: [FunnyGuilds]     at java.lang.Thread.run(Thread.java:748)
```