### PR TITLE
Add legacy configuration migrations

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -12,9 +12,9 @@ dependencies {
     implementation "net.dzikoysk:funnycommands:0.5.2"
 
     // okaeri config library
-    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:3.4.2"
-    implementation "eu.okaeri:okaeri-configs-serdes-commons:3.4.2"
-    implementation "eu.okaeri:okaeri-configs-validator-okaeri:3.4.2"
+    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:4.0.0-beta12"
+    implementation "eu.okaeri:okaeri-configs-serdes-commons:4.0.0-beta12"
+    implementation "eu.okaeri:okaeri-configs-validator-okaeri:4.0.0-beta12"
 
     // general stuff
     //noinspection GradlePackageUpdate

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -12,9 +12,9 @@ dependencies {
     implementation "net.dzikoysk:funnycommands:0.5.2"
 
     // okaeri config library
-    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:4.0.0-beta12"
-    implementation "eu.okaeri:okaeri-configs-serdes-commons:4.0.0-beta12"
-    implementation "eu.okaeri:okaeri-configs-validator-okaeri:4.0.0-beta12"
+    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:4.0.0-beta13"
+    implementation "eu.okaeri:okaeri-configs-serdes-commons:4.0.0-beta13"
+    implementation "eu.okaeri:okaeri-configs-validator-okaeri:4.0.0-beta13"
 
     // general stuff
     //noinspection GradlePackageUpdate

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -12,9 +12,9 @@ dependencies {
     implementation "net.dzikoysk:funnycommands:0.5.2"
 
     // okaeri config library
-    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:4.0.0-beta13"
-    implementation "eu.okaeri:okaeri-configs-serdes-commons:4.0.0-beta13"
-    implementation "eu.okaeri:okaeri-configs-validator-okaeri:4.0.0-beta13"
+    implementation "eu.okaeri:okaeri-configs-yaml-bukkit:4.0.0-beta14"
+    implementation "eu.okaeri:okaeri-configs-serdes-commons:4.0.0-beta14"
+    implementation "eu.okaeri:okaeri-configs-validator-okaeri:4.0.0-beta14"
 
     // general stuff
     //noinspection GradlePackageUpdate

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
@@ -407,6 +407,7 @@ public class FunnyGuilds extends JavaPlugin {
                     this.getNmsAccessor().getPlayerListAccessor(),
                     this.tablistConfiguration.playerList,
                     this.tablistConfiguration.playerListHeader, this.tablistConfiguration.playerListFooter,
+                    this.tablistConfiguration.playerListAnimated,
                     this.tablistConfiguration.pages,
                     this.tablistConfiguration.playerListPing,
                     this.tablistConfiguration.playerListFillCells,

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/concurrency/requests/ReloadRequest.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/concurrency/requests/ReloadRequest.java
@@ -48,6 +48,7 @@ public final class ReloadRequest extends DefaultConcurrencyRequest {
                                 plugin.getNmsAccessor().getPlayerListAccessor(),
                                 tablistConfig.playerList,
                                 tablistConfig.playerListHeader, tablistConfig.playerListFooter,
+                                tablistConfig.playerListAnimated,
                                 tablistConfig.pages,
                                 tablistConfig.playerListPing,
                                 tablistConfig.playerListFillCells,

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/ConfigurationFactory.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/ConfigurationFactory.java
@@ -5,6 +5,7 @@ import eu.okaeri.configs.serdes.commons.SerdesCommons;
 import eu.okaeri.configs.validator.okaeri.OkaeriValidator;
 import eu.okaeri.configs.yaml.bukkit.YamlBukkitConfigurer;
 import java.io.File;
+import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.config.migration.P0001_Fix_freecam_compensation_key_case;
 import net.dzikoysk.funnyguilds.config.migration.P0002_Migrate_old_heart_configuration;
 import net.dzikoysk.funnyguilds.config.migration.P0003_Migrate_old_tnt_protection_configuration;
@@ -44,6 +45,7 @@ public final class ConfigurationFactory {
                 registry.register(new RangeFormattingTransformer());
             });
             it.withBindFile(pluginConfigurationFile);
+            it.withLogger(FunnyGuilds.getInstance().getLogger());
             it.saveDefaults();
             it.load(true);
             it.migrate(

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/ConfigurationFactory.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/ConfigurationFactory.java
@@ -11,6 +11,7 @@ import net.dzikoysk.funnyguilds.config.migration.P0002_Migrate_old_heart_configu
 import net.dzikoysk.funnyguilds.config.migration.P0003_Migrate_old_tnt_protection_configuration;
 import net.dzikoysk.funnyguilds.config.migration.P0004_Migrate_tablist_into_separate_file;
 import net.dzikoysk.funnyguilds.config.migration.P0005_Fix_heart_configuration_centery_key;
+import net.dzikoysk.funnyguilds.config.migration.T0001_Update_player_list_animated;
 import net.dzikoysk.funnyguilds.config.tablist.TablistConfiguration;
 import net.dzikoysk.funnyguilds.config.tablist.TablistPageSerializer;
 import net.dzikoysk.funnyguilds.config.transformer.DecolorTransformer;
@@ -65,6 +66,9 @@ public final class ConfigurationFactory {
             it.withBindFile(tablistConfigurationFile);
             it.saveDefaults();
             it.load(true);
+            it.migrate(
+                    new T0001_Update_player_list_animated()
+            );
         });
     }
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/ConfigurationFactory.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/ConfigurationFactory.java
@@ -5,6 +5,11 @@ import eu.okaeri.configs.serdes.commons.SerdesCommons;
 import eu.okaeri.configs.validator.okaeri.OkaeriValidator;
 import eu.okaeri.configs.yaml.bukkit.YamlBukkitConfigurer;
 import java.io.File;
+import net.dzikoysk.funnyguilds.config.migration.P0001_Fix_freecam_compensation_key_case;
+import net.dzikoysk.funnyguilds.config.migration.P0002_Migrate_old_heart_configuration;
+import net.dzikoysk.funnyguilds.config.migration.P0003_Migrate_old_tnt_protection_configuration;
+import net.dzikoysk.funnyguilds.config.migration.P0004_Migrate_tablist_into_separate_file;
+import net.dzikoysk.funnyguilds.config.migration.P0005_Fix_heart_configuration_centery_key;
 import net.dzikoysk.funnyguilds.config.tablist.TablistConfiguration;
 import net.dzikoysk.funnyguilds.config.tablist.TablistPageSerializer;
 import net.dzikoysk.funnyguilds.config.transformer.DecolorTransformer;
@@ -41,6 +46,13 @@ public final class ConfigurationFactory {
             it.withBindFile(pluginConfigurationFile);
             it.saveDefaults();
             it.load(true);
+            it.migrate(
+                    new P0001_Fix_freecam_compensation_key_case(),
+                    new P0002_Migrate_old_heart_configuration(),
+                    new P0003_Migrate_old_tnt_protection_configuration(),
+                    new P0004_Migrate_tablist_into_separate_file(),
+                    new P0005_Fix_heart_configuration_centery_key()
+            );
         });
     }
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/PluginConfiguration.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/PluginConfiguration.java
@@ -963,7 +963,7 @@ public class PluginConfiguration extends OkaeriConfig {
 
     @Min(0)
     @Comment("Margines sprawdzania przez ile bloków uderzył gracz w serce gildii")
-    @CustomKey("freeCam-compensation")
+    @CustomKey("freecam-compensation")
     public int freeCamCompensation = 0;
 
     @Min(1)

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0001_Fix_freecam_compensation_key_case.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0001_Fix_freecam_compensation_key_case.java
@@ -1,0 +1,15 @@
+package net.dzikoysk.funnyguilds.config.migration;
+
+import eu.okaeri.configs.migrate.builtin.NamedMigration;
+
+import static eu.okaeri.configs.migrate.ConfigMigrationDsl.move;
+
+public class P0001_Fix_freecam_compensation_key_case extends NamedMigration {
+
+    public P0001_Fix_freecam_compensation_key_case() {
+        super(
+                "Rename freeCam-compensation to freecam-compensation",
+                move("freeCam-compensation", "freecam-compensation")
+        );
+    }
+}

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0001_Fix_freecam_compensation_key_case.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0001_Fix_freecam_compensation_key_case.java
@@ -4,6 +4,10 @@ import eu.okaeri.configs.migrate.builtin.NamedMigration;
 
 import static eu.okaeri.configs.migrate.ConfigMigrationDsl.move;
 
+/**
+ * The migration fixes the inconsistency of the {@code freeCam-compensation}
+ * key by renaming it to {@code freecam-compensation}.
+ */
 public class P0001_Fix_freecam_compensation_key_case extends NamedMigration {
 
     public P0001_Fix_freecam_compensation_key_case() {

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0002_Migrate_old_heart_configuration.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0002_Migrate_old_heart_configuration.java
@@ -1,0 +1,20 @@
+package net.dzikoysk.funnyguilds.config.migration;
+
+import eu.okaeri.configs.migrate.builtin.NamedMigration;
+
+import static eu.okaeri.configs.migrate.ConfigMigrationDsl.move;
+
+public class P0002_Migrate_old_heart_configuration extends NamedMigration {
+
+    public P0002_Migrate_old_heart_configuration() {
+        super(
+                "Migrate old top-level keys to heart-configuration subconfig",
+                move("create-type", "heart-configuration.create-type"),
+                move("create-center-y", "heart-configuration.create-center-y"),
+                move("create-center-sphere", "heart-configuration.create-center-sphere"),
+                move("paste-schematic-on-creation", "heart-configuration.paste-schematic-on-creation"),
+                move("guild-schematic-file-name", "heart-configuration.guild-schematic-file-name"),
+                move("paste-schematic-with-air", "heart-configuration.paste-schematic-with-air")
+        );
+    }
+}

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0003_Migrate_old_tnt_protection_configuration.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0003_Migrate_old_tnt_protection_configuration.java
@@ -1,0 +1,18 @@
+package net.dzikoysk.funnyguilds.config.migration;
+
+import eu.okaeri.configs.migrate.builtin.NamedMigration;
+
+import static eu.okaeri.configs.migrate.ConfigMigrationDsl.move;
+
+public class P0003_Migrate_old_tnt_protection_configuration extends NamedMigration {
+
+    public P0003_Migrate_old_tnt_protection_configuration() {
+        super(
+                "Migrate old top-level keys to tnt-protection subconfig",
+                move("guild-tnt-protection-enabled", "tnt-protection.time.enabled"),
+                move("guild-tnt-protection-global", "tnt-protection.time.enabled-global"),
+                move("guild-tnt-protection-start-time", "tnt-protection.time.start-time"),
+                move("guild-tnt-protection-end-time", "tnt-protection.time.end-time")
+        );
+    }
+}

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0004_Migrate_tablist_into_separate_file.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0004_Migrate_tablist_into_separate_file.java
@@ -1,0 +1,52 @@
+package net.dzikoysk.funnyguilds.config.migration;
+
+import eu.okaeri.configs.migrate.ConfigMigration;
+import eu.okaeri.configs.migrate.builtin.NamedMigration;
+import eu.okaeri.configs.migrate.view.RawConfigView;
+import java.io.File;
+import java.util.Objects;
+import net.dzikoysk.funnyguilds.FunnyGuilds;
+import net.dzikoysk.funnyguilds.config.ConfigurationFactory;
+import net.dzikoysk.funnyguilds.config.tablist.TablistConfiguration;
+
+public class P0004_Migrate_tablist_into_separate_file extends NamedMigration {
+
+    private static final ConfigurationFactory CONFIGURATION_FACTORY = new ConfigurationFactory();
+
+    public P0004_Migrate_tablist_into_separate_file() {
+        super(
+                "Migrate old config.yml tablist into tablist.yml",
+                moveToTablistConfig("player-list"),
+                moveToTablistConfig("player-list-header"),
+                moveToTablistConfig("player-list-footer"),
+                moveToTablistConfig("player-list-ping"),
+                moveToTablistConfig("player-list-fill-cells"),
+                moveToTablistConfig("player-list-enable"),
+                moveToTablistConfig("player-list-update-interval"),
+                moveToTablistConfig("player-list-use-relationship-colors")
+        );
+    }
+
+    private static ConfigMigration moveToTablistConfig(String key) {
+        return moveToTablistConfig(key, key);
+    }
+
+    private static ConfigMigration moveToTablistConfig(String localKey, String tablistKey) {
+        return (config, view) -> {
+            if (!view.exists(localKey)) {
+                return false;
+            }
+
+            File tablistConfigurationFile = FunnyGuilds.getInstance().getTablistConfigurationFile();
+            TablistConfiguration tablistConfig = CONFIGURATION_FACTORY.createTablistConfiguration(tablistConfigurationFile);
+            RawConfigView tablistView = new RawConfigView(tablistConfig);
+
+            Object targetValue = view.remove(localKey);
+            Object oldValue = tablistView.set(tablistKey, targetValue);
+
+            tablistConfig.save();
+
+            return !Objects.equals(targetValue, oldValue);
+        };
+    }
+}

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0005_Fix_heart_configuration_centery_key.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0005_Fix_heart_configuration_centery_key.java
@@ -1,0 +1,15 @@
+package net.dzikoysk.funnyguilds.config.migration;
+
+import eu.okaeri.configs.migrate.builtin.NamedMigration;
+
+import static eu.okaeri.configs.migrate.ConfigMigrationDsl.move;
+
+public class P0005_Fix_heart_configuration_centery_key extends NamedMigration {
+
+    public P0005_Fix_heart_configuration_centery_key() {
+        super(
+                "Rename heart-configuration's use-player-position-for-centery to use-player-position-for-center-y",
+                move("heart-configuration.use-player-position-for-centery", "heart-configuration.use-player-position-for-center-y")
+        );
+    }
+}

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0005_Fix_heart_configuration_centery_key.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/P0005_Fix_heart_configuration_centery_key.java
@@ -4,6 +4,15 @@ import eu.okaeri.configs.migrate.builtin.NamedMigration;
 
 import static eu.okaeri.configs.migrate.ConfigMigrationDsl.move;
 
+/**
+ * The migration makes sure {@code use-player-position-for-centery} is changed
+ * into the correct version of {@code use-player-position-for-center-y}.
+ *
+ * The source of the problem is the edge case in the okaeri-configs'
+ * {@link eu.okaeri.configs.annotation.Names} annotation, which was
+ * unable to correctly guess intended format, combined with the missing
+ * CustomKey to force the intended key name from the begging.
+ */
 public class P0005_Fix_heart_configuration_centery_key extends NamedMigration {
 
     public P0005_Fix_heart_configuration_centery_key() {

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/T0001_Update_player_list_animated.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/T0001_Update_player_list_animated.java
@@ -17,7 +17,7 @@ public class T0001_Update_player_list_animated extends NamedMigration {
         super(
                 "Preserve behavior of empty tablist pages by updating player-list-animated",
                 when(
-                        match("pages", (Collection<?> value) -> value.isEmpty()),
+                        match("pages", v -> v instanceof Collection && ((Collection<?>) v).isEmpty()),
                         update("player-list-animated", (old) -> false)
                 )
         );

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/T0001_Update_player_list_animated.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/migration/T0001_Update_player_list_animated.java
@@ -1,0 +1,25 @@
+package net.dzikoysk.funnyguilds.config.migration;
+
+import eu.okaeri.configs.migrate.builtin.NamedMigration;
+import java.util.Collection;
+
+import static eu.okaeri.configs.migrate.ConfigMigrationDsl.match;
+import static eu.okaeri.configs.migrate.ConfigMigrationDsl.update;
+import static eu.okaeri.configs.migrate.ConfigMigrationDsl.when;
+
+/**
+ * The migration makes sure when the tablist.yml value of {@code pages}
+ * is {@code []} to set the {@code player-list-animated} to {@code false}.
+ */
+public class T0001_Update_player_list_animated extends NamedMigration {
+
+    public T0001_Update_player_list_animated() {
+        super(
+                "Preserve behavior of empty tablist pages by updating player-list-animated",
+                when(
+                        match("pages", (Collection<?> value) -> value.isEmpty()),
+                        update("player-list-animated", (old) -> false)
+                )
+        );
+    }
+}

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/sections/HeartConfiguration.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/sections/HeartConfiguration.java
@@ -33,6 +33,7 @@ public class HeartConfiguration extends OkaeriConfig {
     public EntityType createEntityType;
 
     @Comment("Czy poziom na jakim ma byc wyznaczone centrum gildii ma byc ustalany przez pozycje gracza")
+    @CustomKey("use-player-position-for-center-y")
     public boolean usePlayerPositionForCenterY = false;
 
     @Comment("Na jakim poziomie ma byc wyznaczone centrum gildii")

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/tablist/TablistConfiguration.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/tablist/TablistConfiguration.java
@@ -126,7 +126,9 @@ public class TablistConfiguration extends OkaeriConfig {
     @CustomKey("player-list-footer")
     public String playerListFooter = "&c&lWiadomosci braku (pokazujace sie, gdy gracz nie ma gildii) mozna zmienic w pliku messages.yml!";
 
-    @Comment("Aby wylaczyc animowana tabliste ustaw sekcje pages na []")
+    @Comment("Czy animowana tablista ma byc wlaczona?")
+    public boolean playerListAnimated = true;
+
     @Comment("Wartosc cycles to liczba cykli przez ktore widac dana strone na tabliscie. (1 cykl = 1 wyslanie tablisty, czestotliwosc wysylania tablisty mozna zmienic ustawiajac wartosc playerListUpdateInterval)")
     @Comment("Sekcje player-list konfiguruje sie w ten sam sposob co zwykla. Ustawia sie w niej wszystkie komorki, ktore maja sie zmieniac (nadpisujac zwykla konfiguracje).")
     @Comment("Sekcje player-list-header konfiguruje sie w ten sam sposob co zwykla.")

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/tablist/TablistPageSerializer.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/tablist/TablistPageSerializer.java
@@ -5,16 +5,17 @@ import eu.okaeri.configs.serdes.DeserializationData;
 import eu.okaeri.configs.serdes.ObjectSerializer;
 import eu.okaeri.configs.serdes.SerializationData;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
 
 public class TablistPageSerializer implements ObjectSerializer<TablistPage> {
 
     @Override
-    public boolean supports(Class<? super TablistPage> type) {
+    public boolean supports(@NotNull Class<? super TablistPage> type) {
         return TablistPage.class.isAssignableFrom(type);
     }
 
     @Override
-    public void serialize(TablistPage page, SerializationData data) {
+    public void serialize(TablistPage page, SerializationData data, @NotNull GenericsDeclaration generics) {
         data.add("cycles", page.cycles);
 
         if (page.playerList != null) {
@@ -31,7 +32,7 @@ public class TablistPageSerializer implements ObjectSerializer<TablistPage> {
     }
 
     @Override
-    public TablistPage deserialize(DeserializationData data, GenericsDeclaration generics) {
+    public TablistPage deserialize(DeserializationData data, @NotNull GenericsDeclaration generics) {
         int cycles = data.get("cycles", Integer.class);
 
         Map<Integer, String> playerList = data.containsKey("player-list")

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/tablist/IndividualPlayerList.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/tablist/IndividualPlayerList.java
@@ -32,6 +32,7 @@ public class IndividualPlayerList {
     private final String footer;
     private final int cellPing;
 
+    private final boolean animated;
     private final List<TablistPage> pages;
     private final int pagesCount;
 
@@ -44,6 +45,7 @@ public class IndividualPlayerList {
                                 PlayerListAccessor playerListAccessor,
                                 Map<Integer, String> unformattedCells,
                                 String header, String footer,
+                                boolean animated,
                                 List<TablistPage> pages,
                                 int cellPing,
                                 boolean fillCells,
@@ -54,6 +56,7 @@ public class IndividualPlayerList {
         this.unformattedCells = new HashMap<>(unformattedCells);
         this.header = header;
         this.footer = footer;
+        this.animated = animated;
         this.pages = pages;
         this.pagesCount = pages.size();
         this.cellPing = cellPing;
@@ -84,7 +87,7 @@ public class IndividualPlayerList {
         String header = this.header;
         String footer = this.footer;
 
-        if (this.pagesCount > 0) {
+        if (this.animated) {
             this.cycle++;
 
             int pageCycles = this.pages.get(this.currentPage).cycles;

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerJoin.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerJoin.java
@@ -39,6 +39,7 @@ public class PlayerJoin extends AbstractFunnyListener {
                     this.nmsAccessor.getPlayerListAccessor(),
                     tablistConfig.playerList,
                     tablistConfig.playerListHeader, tablistConfig.playerListFooter,
+                    tablistConfig.playerListAnimated,
                     tablistConfig.pages,
                     tablistConfig.playerListPing,
                     tablistConfig.playerListFillCells,


### PR DESCRIPTION
This PR aims to fix partial configuration loss when upgrading from 4.9.7 to 4.10.0 by:
- updating `okaeri-configs` to `4.0.0-beta13` for built-in migrations
- creating `net.dzikoysk.funnyguilds.config.migration` package for further migrations

## Included migrations
### Critical
  - `P0002_Migrate_old_heart_configuration: Migrate` old top-level keys to heart-configuration subconfig
  - `P0003_Migrate_old_tnt_protection_configuration`: Migrate old top-level keys to tnt-protection subconfig
  - `P0004_Migrate_tablist_into_separate_file`: Migrate old config.yml tablist into tablist.yml
  - `T0001_Update_player_list_animated`: Preserve behavior of empty tablist pages by updating player-list-animated
### Cosmetic
  - `P0001_Fix_freecam_compensation_key_case`: Rename freeCam-compensation to freecam-compensation
  - `P0005_Fix_heart_configuration_centery_key`: Rename heart-configuration's use-player-position-for-centery to use-player-position-for-center-y

## Key concepts

The `migration` package contains migrations for all the plugin configs, where files are named by this scheme:

- config prefix, where for example `P` is derived from **P**luginConfiguration.
- numeral marking migration order, padded with zeros to 4 digits (this allows up to 9,999 migrations with no renames)
- separating underscore for better readability
- short title where the spaces are replaced with underscore

## Migration logging

When migration completes with changes, the log message is produced. Example:

```
[21:56:11 INFO]: [FunnyGuilds] P0001_Fix_freecam_compensation_key_case: Rename freeCam-compensation to freecam-compensation
```

## Migration DSL

While current migrations do not contain complicated actions, it is possible to both create custom migrations with own logic by implementing `ConfigMigration` and to use dsl-like migration pattern:

![image](https://user-images.githubusercontent.com/44551064/160299468-bc1aa29b-7782-45ba-a32c-576e6f8bdf15.png)
