### PR TITLE
Add fallback FunnyTime parsing as minutes from midnight (Fixes #1603)

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/FunnyTime.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/FunnyTime.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 public class FunnyTime {
 
-    public static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    public static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("H:mm");
 
     private final LocalTime time;
     private final String formattedTime;

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/transformer/FunnyTimeTransformer.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/transformer/FunnyTimeTransformer.java
@@ -5,6 +5,7 @@ import eu.okaeri.configs.serdes.BidirectionalTransformer;
 import eu.okaeri.configs.serdes.SerdesContext;
 import java.time.LocalTime;
 import net.dzikoysk.funnyguilds.config.FunnyTime;
+import org.jetbrains.annotations.NotNull;
 
 public class FunnyTimeTransformer extends BidirectionalTransformer<String, FunnyTime> {
 
@@ -14,12 +15,44 @@ public class FunnyTimeTransformer extends BidirectionalTransformer<String, Funny
     }
 
     @Override
-    public FunnyTime leftToRight(String data, SerdesContext serdesContext) {
-        return new FunnyTime(LocalTime.parse(data, FunnyTime.TIME_FORMATTER));
+    public FunnyTime leftToRight(@NotNull String data, @NotNull SerdesContext serdesContext) {
+
+        // standard parse from string
+        if (data.contains(":")) {
+            return new FunnyTime(LocalTime.parse(data, FunnyTime.TIME_FORMATTER));
+        }
+
+        // something went wrong, probably yaml spec, whoopsie... https://noyaml.com/
+        int value;
+        try {
+            value = Integer.parseInt(data);
+        }
+        catch (NumberFormatException exception) {
+            throw new IllegalArgumentException("Cannot resolve time from " + data, exception);
+        }
+
+        // the value is above 24 hours in both cases
+        if (value > 86400) {
+            throw new IllegalArgumentException("Cannot resolve time from " + value);
+        }
+
+        // value in minutes is above 24 hours
+        // restore as seconds from midnight
+        // 00:00 - 00:24 may have bad time
+        if (value > 1440) {
+            int hours = value / 3600;
+            int minutes = (value % 3600) / 60;
+            return new FunnyTime(LocalTime.of(hours, minutes));
+        }
+
+        // restore as minutes from midnight
+        int hours = value / 60;
+        int minutes = value % 60;
+        return new FunnyTime(LocalTime.of(hours, minutes));
     }
 
     @Override
-    public String rightToLeft(FunnyTime data, SerdesContext serdesContext) {
+    public String rightToLeft(@NotNull FunnyTime data, @NotNull SerdesContext serdesContext) {
         return data.getFormattedTime();
     }
 


### PR DESCRIPTION
This PR is brought to you by YAML specification. Order your copy now and get 10% off by converting `key: 10:00` into `key: 600`.