### PR TITLE
Add Multiverse-Core as a soft dependency

### DIFF
--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: net.dzikoysk.funnyguilds.FunnyGuilds
 version: '@funnyGuildsVersion@ Snowdrop-@funnyGuildsCommit@'
 author: 'FunnyGuilds Team'
 website: https://github.com/FunnyGuilds
-softdepend: [WorldEdit, WorldGuard, Vault, PlaceholderAPI, FunnyTab, BungeeTabListPlus, MVdWPlaceholderAPI, HolographicDisplays]
+softdepend: [WorldEdit, WorldGuard, Vault, PlaceholderAPI, FunnyTab, BungeeTabListPlus, MVdWPlaceholderAPI, HolographicDisplays, Multiverse-Core]
 api-version: 1.13
 
 permissions:


### PR DESCRIPTION
FunnyGuilds loads before the Multiverse-Core, causing guilds on Multiverse worlds to be moved to the default world.