### PR TITLE
Reverse "Update ItemUtils.java" and fix critical parsing error

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/shared/bukkit/ItemUtils.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/shared/bukkit/ItemUtils.java
@@ -119,13 +119,14 @@ public final class ItemUtils {
         });
 
         ItemBuilder item = new ItemBuilder(material, amount.orElseGet(1), data.orElseGet(0));
-        FunnyFormatter formatter = new FunnyFormatter().register("_", "").register("{HASH}", "#");
+        FunnyFormatter formatter = new FunnyFormatter().register("_", " ").register("{HASH}", "#");
 
         for (int index = 2; index < split.length; index++) {
             String[] itemAttributes = split[index].split(":", 2);
 
             if (itemAttributes.length != 2) {
                 FunnyGuilds.getPluginLogger().parser("Unknown item meta attribute: " + itemAttributes[0]);
+                continue;
             }
 
             String attributeName = itemAttributes[0];


### PR DESCRIPTION
This PR is fixing critical config parsing error. There was a missing `continue;` statement in the previous release that caused plugin to crash with default configuration.