### PR TITLE
Fix broadcasting tablist

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/tablist/TablistBroadcastHandler.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/tablist/TablistBroadcastHandler.java
@@ -26,7 +26,9 @@ public class TablistBroadcastHandler implements Runnable {
         PandaStream.of(Bukkit.getOnlinePlayers())
                 .flatMap(userManager::findByPlayer)
                 .flatMap(user -> user.getCache().getPlayerList())
-                .forEach(IndividualPlayerList::updatePageCycle)
-                .forEach(IndividualPlayerList::send);
+                .forEach(playerList -> {
+                    playerList.updatePageCycle();
+                    playerList.send();
+                });
     }
 }


### PR DESCRIPTION
```
[21:17:56] [Craft Scheduler Thread - 4/WARN]: Exception in thread "Craft Scheduler Thread - 4" 
[21:17:56] [Craft Scheduler Thread - 4/WARN]: org.apache.commons.lang.UnhandledException: Plugin FunnyGuilds v4.10.2-SNAPSHOTS Snowdrop-fbfa5cd generated an exception while executing task 6
	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
	at org.github.paperspigot.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:23)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.IllegalStateException: stream has already been operated upon or closed
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:229)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at panda.std.stream.PandaStream.forEach(PandaStream.java:230)
	at net.dzikoysk.funnyguilds.feature.tablist.TablistBroadcastHandler.run(TablistBroadcastHandler.java:30)
	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:64)
	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:53)
	... 4 more
```