### PR TITLE
Fix server shutdown

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
@@ -211,7 +211,7 @@ public class FunnyGuilds extends JavaPlugin {
             this.nmsAccessor = prepareNmsAccessor();
         }
         catch (Exception exception) {
-            logger.error("Could not prepare NMS accessor", exception);
+            logger.error(String.format("Unsupported server version: %s", Reflections.SERVER_VERSION), exception);
             this.shutdown("Critical error has been encountered!");
             return;
         }
@@ -706,7 +706,7 @@ public class FunnyGuilds extends JavaPlugin {
                 return new V1_19R2NmsAccessor();
             default:
                 throw new IllegalStateException(String.format(
-                        "Could not find matching NmsAccessor for currently running server version: %s", Reflections.SERVER_VERSION
+                        "Could not find applicable NmsAccessor. Unsupported server version: %s", Reflections.SERVER_VERSION
                 ));
         }
     }

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
@@ -209,7 +209,8 @@ public class FunnyGuilds extends JavaPlugin {
 
         try {
             this.nmsAccessor = prepareNmsAccessor();
-        } catch (Exception exception) {
+        }
+        catch (Exception exception) {
             logger.error("Could not prepare NMS accessor", exception);
             this.shutdown("Critical error has been encountered!");
             return;
@@ -675,7 +676,12 @@ public class FunnyGuilds extends JavaPlugin {
         return logger;
     }
 
-    private static NmsAccessor prepareNmsAccessor() {
+    private static NmsAccessor prepareNmsAccessor() throws IllegalStateException {
+        if (true) {
+            throw new IllegalStateException(String.format(
+                    "Could not find matching NmsAccessor for currently running server version: %s", Reflections.SERVER_VERSION
+            ));
+        }
         switch (Reflections.SERVER_VERSION) {
             case "v1_8_R3":
                 return new V1_8R3NmsAccessor();

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
@@ -677,11 +677,6 @@ public class FunnyGuilds extends JavaPlugin {
     }
 
     private static NmsAccessor prepareNmsAccessor() throws IllegalStateException {
-        if (true) {
-            throw new IllegalStateException(String.format(
-                    "Could not find matching NmsAccessor for currently running server version: %s", Reflections.SERVER_VERSION
-            ));
-        }
         switch (Reflections.SERVER_VERSION) {
             case "v1_8_R3":
                 return new V1_8R3NmsAccessor();

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/FunnyGuilds.java
@@ -207,7 +207,13 @@ public class FunnyGuilds extends JavaPlugin {
             return;
         }
 
-        this.nmsAccessor = prepareNmsAccessor();
+        try {
+            this.nmsAccessor = prepareNmsAccessor();
+        } catch (Exception exception) {
+            logger.error("Could not prepare NMS accessor", exception);
+            this.shutdown("Critical error has been encountered!");
+            return;
+        }
         this.guildEntityHelper = new GuildEntityHelper(this.pluginConfiguration, this.nmsAccessor);
 
         DescriptionChanger descriptionChanger = new DescriptionChanger(super.getDescription());

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/shared/bukkit/NmsUtils.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/shared/bukkit/NmsUtils.java
@@ -21,7 +21,11 @@ public final class NmsUtils {
     }
 
     public static int getReloadCount() {
-        return FunnyGuilds.getInstance().getNmsAccessor().getStatisticsAccessor().getReloadCount();
+        try {
+            return FunnyGuilds.getInstance().getNmsAccessor().getStatisticsAccessor().getReloadCount();
+        } catch (Exception ex) {
+            return -1;
+        }
     }
 
     public static int getPing(Player player) {


### PR DESCRIPTION
Gdy nie wykryto odpowiedniego `NmsAccessora` to rzucaliśmy wyjątek przez `FunnyGuildsLogger` - a on... używał tego NmsAccessora do sprawdzania ilości przeładowań serwera więc FunnyGuilds#shutdown nie było nawet callowane 

Dodatkowo został poprawiony exception rzucany userom, aby osoby mniej techniczne były w stanie zrozumieć dlaczego plugin nie działa