### PR TITLE
GH-2276 Mitigate player list entry sorting when using ViaVersion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ allprojects {
         maven("https://nexus.codecrafter47.de/content/repositories/public")
         maven("https://repo.codemc.io/repository/maven-public")
         maven("https://jitpack.io")
+        maven("https://repo.viaversion.com")
     }
 }
 

--- a/nms/api/build.gradle.kts
+++ b/nms/api/build.gradle.kts
@@ -2,4 +2,6 @@ dependencies {
     shadow("org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT")
 
     shadow("com.mojang:authlib:3.2.38")
+
+    shadow("com.viaversion:viaversion-api:[4.0.0,5.0.0)")
 }

--- a/nms/api/src/main/java/net/dzikoysk/funnyguilds/nms/api/ProtocolDependentHelper.java
+++ b/nms/api/src/main/java/net/dzikoysk/funnyguilds/nms/api/ProtocolDependentHelper.java
@@ -1,0 +1,47 @@
+package net.dzikoysk.funnyguilds.nms.api;
+
+import com.viaversion.viaversion.api.Via;
+import org.bukkit.entity.Player;
+
+public class ProtocolDependentHelper {
+    private static final int V1_19_3_PROTOCOL_VERSION = 761;
+
+    private static boolean viaApiAvailable = false;
+
+    static {
+        try {
+            Class.forName("com.viaversion.viaversion.api.ViaAPI");
+            viaApiAvailable = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+    }
+
+    public static String getGameProfileNameBasedOnPlayerProtocolVersion(Player player, String paddedIdentifier, String defaultIdentifier) {
+        // NOTE: Sorting changed in 1.19.3 and GameProfile name is being included in the sorting process.
+        //       To mitigate it when server is using ViaVersion and client protocol version mismatches with the server protocol version,
+        //       we're checking the protocol version that player uses and return proper identifier for specific version.
+        Integer playerProtocolVersion = getPlayerProtocolVersion(player);
+
+        if (playerProtocolVersion == null) {
+            return defaultIdentifier;
+        }
+
+        if (playerProtocolVersion >= V1_19_3_PROTOCOL_VERSION) {
+            return paddedIdentifier;
+        }
+
+        return " ";
+    }
+
+    private static Integer getPlayerProtocolVersion(Player player) {
+        if (!viaApiAvailable) {
+            return null;
+        }
+
+        return getPlayerProtocolVersionImpl(player);
+    }
+
+    private static Integer getPlayerProtocolVersionImpl(Player player) {
+        return Via.getAPI().getPlayerVersion(player.getUniqueId());
+    }
+}

--- a/nms/v1_10R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_10R1/playerlist/V1_10R1PlayerList.java
+++ b/nms/v1_10R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_10R1/playerlist/V1_10R1PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -61,10 +63,13 @@ public class V1_10R1PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_11R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_11R1/playerlist/V1_11R1PlayerList.java
+++ b/nms/v1_11R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_11R1/playerlist/V1_11R1PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -61,10 +63,13 @@ public class V1_11R1PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_12R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_12R1/playerlist/V1_12R1PlayerList.java
+++ b/nms/v1_12R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_12R1/playerlist/V1_12R1PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -65,10 +67,13 @@ public class V1_12R1PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_13R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_13R2/playerlist/V1_13R2PlayerList.java
+++ b/nms/v1_13R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_13R2/playerlist/V1_13R2PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -56,10 +58,13 @@ public class V1_13R2PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_14R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_14R1/playerlist/V1_14R1PlayerList.java
+++ b/nms/v1_14R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_14R1/playerlist/V1_14R1PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -56,10 +58,13 @@ public class V1_14R1PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_15R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_15R1/playerlist/V1_15R1PlayerList.java
+++ b/nms/v1_15R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_15R1/playerlist/V1_15R1PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -57,10 +59,13 @@ public class V1_15R1PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_16R3/src/main/java/net/dzikoysk/funnyguilds/nms/v1_16R3/playerlist/V1_16R3PlayerList.java
+++ b/nms/v1_16R3/src/main/java/net/dzikoysk/funnyguilds/nms/v1_16R3/playerlist/V1_16R3PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -57,10 +59,13 @@ public class V1_16R3PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_17R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_17R1/playerlist/V1_17R1PlayerList.java
+++ b/nms/v1_17R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_17R1/playerlist/V1_17R1PlayerList.java
@@ -5,6 +5,8 @@ import com.mojang.authlib.GameProfile;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -41,10 +43,13 @@ public class V1_17R1PlayerList implements PlayerList {
 
         try {
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_18R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_18R2/playerlist/V1_18R2PlayerList.java
+++ b/nms/v1_18R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_18R2/playerlist/V1_18R2PlayerList.java
@@ -5,6 +5,8 @@ import com.mojang.authlib.GameProfile;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -41,10 +43,13 @@ public class V1_18R2PlayerList implements PlayerList {
 
         try {
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_19R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_19R1/playerlist/V1_19R1PlayerList.java
+++ b/nms/v1_19R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_19R1/playerlist/V1_19R1PlayerList.java
@@ -5,6 +5,8 @@ import com.mojang.authlib.GameProfile;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -41,10 +43,13 @@ public class V1_19R1PlayerList implements PlayerList {
 
         try {
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_19R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_19R2/playerlist/V1_19R2PlayerList.java
+++ b/nms/v1_19R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_19R2/playerlist/V1_19R2PlayerList.java
@@ -2,6 +2,7 @@ package net.dzikoysk.funnyguilds.nms.v1_19R2.playerlist;
 
 import com.google.common.collect.Lists;
 import com.mojang.authlib.GameProfile;
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -60,11 +61,12 @@ public class V1_19R2PlayerList implements PlayerList {
         try {
             for (int i = 0; i < this.cellCount; i++) {
                 String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, paddedIdentifier);
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(
-                                    PlayerListConstants.UUID_PATTERN, paddedIdentifier)
-                            ), paddedIdentifier
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_8R3/src/main/java/net/dzikoysk/funnyguilds/nms/v1_8R3/playerlist/V1_8R3PlayerList.java
+++ b/nms/v1_8R3/src/main/java/net/dzikoysk/funnyguilds/nms/v1_8R3/playerlist/V1_8R3PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -60,10 +62,13 @@ public class V1_8R3PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 

--- a/nms/v1_9R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_9R2/playerlist/V1_9R2PlayerList.java
+++ b/nms/v1_9R2/src/main/java/net/dzikoysk/funnyguilds/nms/v1_9R2/playerlist/V1_9R2PlayerList.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.SkinTexture;
@@ -61,10 +63,13 @@ public class V1_9R2PlayerList implements PlayerList {
             PacketPlayOutPlayerInfo updatePlayerPacket = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
 
             for (int i = 0; i < this.cellCount; i++) {
+                String paddedIdentifier = StringUtils.leftPad(String.valueOf(i), 2, '0');
+                String gameProfileName = ProtocolDependentHelper.getGameProfileNameBasedOnPlayerProtocolVersion(player, paddedIdentifier, " ");
+
                 if (this.profileCache[i] == null) {
                     this.profileCache[i] = new GameProfile(
-                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, StringUtils.leftPad(String.valueOf(i), 2, '0'))),
-                            " "
+                            UUID.fromString(String.format(PlayerListConstants.UUID_PATTERN, paddedIdentifier)),
+                            gameProfileName
                     );
                 }
 


### PR DESCRIPTION
In 1.19.3 player list entry sorting got changed and it includes GameProfile name in the sorting process.

To allow players joining with 1.19.3 client on <1.19.3 servers and having proper sorting on the player list, player list now uses proper GameProfile name based on the client's protocol version, retrieved from the ViaVersion's API.