### PR TITLE
Remove english locale from default available locales

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/PluginConfiguration.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/PluginConfiguration.java
@@ -94,7 +94,7 @@ public class PluginConfiguration extends OkaeriConfig {
     @Comment("Lista języków używanych przez plugin")
     @Comment("Jeżeli chcesz dodać nowy język dodaj go tutaj - utworzy to nowy plik z domyślnymi wartościami, które możesz później edytować")
     @Comment("Języki gracza są dobierane automatycznie na podstawie ustawiań klienta")
-    public Set<Locale> availableLocales = new HashSet<>(Arrays.asList(Locale.forLanguageTag("pl"), Locale.forLanguageTag("en")));
+    public Set<Locale> availableLocales = new HashSet<>(Arrays.asList(Locale.forLanguageTag("pl")));
 
     @Comment("")
     @Comment("Czy ma być włączona możliwość zakładania gildii (można ją zmienić także za pomocą komendy /ga enabled)")


### PR DESCRIPTION
Jako iż nie mamy angielskiego tłumaczenia to nie ma sensu niepotrzebnie generować pliku. Może to wprowadzać w błąd użytkowników