### PR TITLE
Improve region move handling and fix teleportation

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionEnterEvent.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionEnterEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Called when a player enters a guild region by crossing the border or teleports into it
+ * Called when a player enters a guild region by crossing it's border or teleports into it
  */
 public class GuildRegionEnterEvent extends GuildEvent {
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionEnterEvent.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionEnterEvent.java
@@ -5,6 +5,9 @@ import net.dzikoysk.funnyguilds.user.User;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Called when a player enters a guild region by crossing the border or teleports into it
+ */
 public class GuildRegionEnterEvent extends GuildEvent {
 
     private static final HandlerList handlers = new HandlerList();

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionEnterEvent.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionEnterEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Called when a player enters a guild region by crossing it's border or teleports into it
+ * Called when a player enters a guild region by crossing it's border or teleporting into it
  */
 public class GuildRegionEnterEvent extends GuildEvent {
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionLeaveEvent.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionLeaveEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Called when a player leaves a guild region by crossing the border or teleports out of it
+ * Called when a player leaves a guild region by crossing it's border or teleports out of it
  */
 public class GuildRegionLeaveEvent extends GuildEvent {
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionLeaveEvent.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionLeaveEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Called when a player leaves a guild region by crossing it's border or teleports out of it
+ * Called when a player leaves a guild region by crossing it's border or teleporting out of it
  */
 public class GuildRegionLeaveEvent extends GuildEvent {
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionLeaveEvent.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/event/guild/GuildRegionLeaveEvent.java
@@ -5,6 +5,9 @@ import net.dzikoysk.funnyguilds.user.User;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Called when a player leaves a guild region by crossing the border or teleports out of it
+ */
 public class GuildRegionLeaveEvent extends GuildEvent {
 
     private static final HandlerList handlers = new HandlerList();

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/region/PlayerMove.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/region/PlayerMove.java
@@ -21,7 +21,7 @@ public class PlayerMove extends AbstractFunnyListener {
 
     @EventHandler
     public void onTeleport(PlayerTeleportEvent event) {
-        this.onMove(event);
+        this.onMove(event); // We have to manually call onMove when player teleports - in other case the move event won't be called
     }
 
     @EventHandler

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/region/PlayerMove.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/region/PlayerMove.java
@@ -21,13 +21,6 @@ public class PlayerMove extends AbstractFunnyListener {
 
     @EventHandler
     public void onTeleport(PlayerTeleportEvent event) {
-        boolean enter = event.getTo() != null
-                ? !this.regionManager.findRegionAtLocation(event.getTo()).equals(this.regionManager.findRegionAtLocation(event.getFrom()))
-                : false;
-        this.userManager.findByUuid(event.getPlayer().getUniqueId())
-                .map(User::getCache)
-                .peek(userCache -> userCache.setEnter(enter));
-
         this.onMove(event);
     }
 
@@ -36,7 +29,6 @@ public class PlayerMove extends AbstractFunnyListener {
         Location from = event.getFrom();
         Location to = event.getTo();
         Player player = event.getPlayer();
-
         if (to == null) {
             return;
         }
@@ -54,82 +46,79 @@ public class PlayerMove extends AbstractFunnyListener {
             User user = userOption.get();
             UserCache cache = user.getCache();
 
+            Option<Region> regionOptionFrom = this.regionManager.findRegionAtLocation(from);
             Option<Region> regionOptionTo = this.regionManager.findRegionAtLocation(to);
-            
-            if (cache.getEnter()) {
-                Option<Region> regionOptionFrom = this.regionManager.findRegionAtLocation(from);
-                if (regionOptionTo.equals(regionOptionFrom)) {
-                    return;
-                }
-                
-                cache.setEnter(false);
 
-                regionOptionFrom
-                        .map(Region::getGuild)
-                        .peek(guild -> {
-                            if (!SimpleEventHandler.handle(new GuildRegionLeaveEvent(EventCause.USER, user, guild))) {
-                                event.setCancelled(true);
-                                return;
-                            }
-
-                            FunnyFormatter formatter = new FunnyFormatter()
-                                    .register("{GUILD}", guild.getName())
-                                    .register("{TAG}", guild.getTag());
-
-                            this.messageService.getMessage(config -> config.notificationLeaveGuildRegion)
-                                    .with(formatter)
-                                    .receiver(player)
-                                    .send();
-                        });
+            if (regionOptionFrom.equals(regionOptionTo)) {
+                return;
             }
-            else {
-                regionOptionTo
-                        .map(Region::getGuild)
-                        .peek(guild -> {
-                            if (!SimpleEventHandler.handle(new GuildRegionEnterEvent(EventCause.USER, user, guild))) {
-                                event.setCancelled(true);
-                                return;
-                            }
 
-                            cache.setEnter(true);
+            regionOptionFrom
+                    .map(Region::getGuild)
+                    .peek(guild -> {
+                        this.logger.debug(String.format("Player %s left region of guild %s", player.getName(), guild.getName()));
 
-                            if (this.config.heart.createEntityType != null) {
-                                Bukkit.getScheduler().runTaskLaterAsynchronously(this.plugin, () -> {
-                                    this.guildEntityHelper.spawnGuildEntity(guild, player);
-                                }, 40L);
-                            }
+                        if (!SimpleEventHandler.handle(new GuildRegionLeaveEvent(EventCause.USER, user, guild))) {
+                            event.setCancelled(true);
+                            return;
+                        }
 
-                            FunnyFormatter formatter = new FunnyFormatter()
-                                    .register("{GUILD}", guild.getName())
-                                    .register("{TAG}", guild.getTag())
-                                    .register("{PLAYER}", player.getName());
+                        FunnyFormatter formatter = new FunnyFormatter()
+                                .register("{GUILD}", guild.getName())
+                                .register("{TAG}", guild.getTag());
 
-                            this.messageService.getMessage(config -> config.notificationEnterGuildRegion)
-                                    .with(formatter)
-                                    .receiver(player)
-                                    .send();
+                        this.messageService.getMessage(config -> config.notificationLeaveGuildRegion)
+                                .with(formatter)
+                                .receiver(player)
+                                .send();
+                    });
 
-                            if (player.hasPermission("funnyguilds.admin.notification")) {
-                                return;
-                            }
+            regionOptionTo
+                    .map(Region::getGuild)
+                    .peek(guild -> {
+                        this.logger.debug(String.format("Player %s entered region of guild %s", player.getName(), guild.getName()));
 
-                            if (cache.getNotificationTime() > 0 && System.currentTimeMillis() < cache.getNotificationTime()) {
-                                return;
-                            }
+                        if (!SimpleEventHandler.handle(new GuildRegionEnterEvent(EventCause.USER, user, guild))) {
+                            event.setCancelled(true);
+                            return;
+                        }
 
-                            if (!this.config.regionEnterNotificationGuildMember && user.hasGuild() &&
-                                    guild.getTag().equals(user.getGuild().get().getTag())) {
-                                return;
-                            }
+                        if (this.config.heart.createEntityType != null) {
+                            Bukkit.getScheduler().runTaskLaterAsynchronously(this.plugin, () -> {
+                                this.guildEntityHelper.spawnGuildEntity(guild, player);
+                            }, 40L);
+                        }
 
-                            this.messageService.getMessage(config -> config.notificationIntruderEnterGuildRegion)
-                                    .with(formatter)
-                                    .receiver(guild)
-                                    .send();
+                        FunnyFormatter formatter = new FunnyFormatter()
+                                .register("{GUILD}", guild.getName())
+                                .register("{TAG}", guild.getTag())
+                                .register("{PLAYER}", player.getName());
 
-                            cache.setNotificationTime(System.currentTimeMillis() + 1000L * this.config.regionNotificationCooldown);
-                        });
-            }
+                        this.messageService.getMessage(config -> config.notificationEnterGuildRegion)
+                                .with(formatter)
+                                .receiver(player)
+                                .send();
+
+                        if (player.hasPermission("funnyguilds.admin.notification")) {
+                            return;
+                        }
+
+                        if (cache.getNotificationTime() > 0 && System.currentTimeMillis() < cache.getNotificationTime()) {
+                            return;
+                        }
+
+                        if (!this.config.regionEnterNotificationGuildMember && user.hasGuild() &&
+                                guild.getTag().equals(user.getGuild().get().getTag())) {
+                            return;
+                        }
+
+                        this.messageService.getMessage(config -> config.notificationIntruderEnterGuildRegion)
+                                .with(formatter)
+                                .receiver(guild)
+                                .send();
+
+                        cache.setNotificationTime(System.currentTimeMillis() + 1000L * this.config.regionNotificationCooldown);
+                    });
         });
     }
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/user/UserCache.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/user/UserCache.java
@@ -21,7 +21,6 @@ public class UserCache {
 
     private BukkitTask teleportation;
     private long notificationTime;
-    private boolean enter;
     private boolean spy;
 
     public UserCache(User user) {
@@ -79,14 +78,6 @@ public class UserCache {
 
     public void setNotificationTime(long notification) {
         this.notificationTime = notification;
-    }
-
-    public boolean getEnter() {
-        return this.enter;
-    }
-
-    public void setEnter(boolean enter) {
-        this.enter = enter;
     }
 
     public boolean isSpy() {


### PR DESCRIPTION
PR ten:
1. Rozwiązuje problem, który miał być naprawiony przez #2364 
2. Upraszcza system pozbywając się  get/setEnter, który mógł się bugować przy m.in teleportacji
3. Poprawnie wywołuje event od wyjścia i wejścia na teren gildii, gdy przechodzi się z terenu gildii od razu na teren innej gildii

Jedyną wadą nowego rozwiązania jest to, że robimy zawsze dodatkowy lookup na region,który opuściliśmy. Jednak po zmianach @insertt szukanie regionu po lokalizacji nie powinno powodować większych problemów z wydajnością. Dodatkowo sam lookup jest robiony asynchronicznie, więc nie powinno być żadnych odczuwalnych lagów