### PR TITLE
Make PlayerDeathEvent ignore cancelled event

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerDeath.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerDeath.java
@@ -51,7 +51,7 @@ public class PlayerDeath extends AbstractFunnyListener {
         this.rankSystem = RankSystem.create(config);
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onDeath(PlayerDeathEvent event) {
         Player playerVictim = event.getEntity();
         Player playerAttacker = event.getEntity().getKiller();


### PR DESCRIPTION
On Paper PlayerDeathEvent might be cancelled, FG does not behave correctly if said event is cancelled