### PR TITLE
Fix for guild regions for negative coordinates

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/guild/RegionManager.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/guild/RegionManager.java
@@ -89,7 +89,7 @@ public class RegionManager {
      * @return the region
      */
     public Option<Region> findRegionAtLocation(Location location) {
-        long packedPos = packChunkPosition(location.getBlockX() / 16, location.getBlockZ() / 16);
+        long packedPos = packChunkPosition(location.getBlockX() >> 4, location.getBlockZ() >> 4);
         Set<Region> applicableRegions = this.regions.get(packedPos);
 
         if (applicableRegions == null || applicableRegions.isEmpty()) {
@@ -287,11 +287,11 @@ public class RegionManager {
      * and applies given function for every chunk position.
      */
     private void forEachChunkPositionInRegion(Region region, BiConsumer<Integer, Integer> chunkPosFunc) {
-        int firstX = region.getFirstCorner().getBlockX() / 16;
-        int firstZ = region.getFirstCorner().getBlockZ() / 16;
+        int firstX = region.getFirstCorner().getBlockX() >> 4;
+        int firstZ = region.getFirstCorner().getBlockZ() >> 4;
 
-        int secondX = region.getSecondCorner().getBlockX() / 16;
-        int secondZ = region.getSecondCorner().getBlockZ() / 16;
+        int secondX = region.getSecondCorner().getBlockX() >> 4;
+        int secondZ = region.getSecondCorner().getBlockZ() >> 4;
 
         int startX = Math.min(firstX, secondX);
         int startZ = Math.min(firstZ, secondZ);


### PR DESCRIPTION
Well... chunks located on negative coordinates are not correctly calculated. This cause trimming of region protection to last fully contained chunk. So, in unfortunate situation, player can have 100x100 guild with effective region of 85x85

Here's the cause:
```java
// Output: (0, 0, 0)
System.out.printf("Wrong: (%d, %d, %d)%n", 15 / 16, 0 / 16, -15 / 16);

// Output (0, 0, -1)
System.out.printf("Correct: (%d, %d, %d)%n", 15 >> 4, 0 >> 4, -15 >> 4);
```
In short: When dividing negative number, the result is rounded up (not down)