### PR TITLE
Add WorldGuard `friendly-fire` flag

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/worldguard/WorldGuard6Hook.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/worldguard/WorldGuard6Hook.java
@@ -44,6 +44,7 @@ public class WorldGuard6Hook extends WorldGuardHook {
     private WorldGuardPlugin worldGuard;
     private StateFlag noPointsFlag;
     private StateFlag noGuildsFlag;
+    private StateFlag friendlyFireFlag;
 
     public WorldGuard6Hook(String name) {
         super(name);
@@ -54,6 +55,7 @@ public class WorldGuard6Hook extends WorldGuardHook {
         this.worldGuard = WorldGuardPlugin.inst();
         this.noPointsFlag = new StateFlag("fg-no-points", false);
         this.noGuildsFlag = new StateFlag("fg-no-guilds", false);
+        this.friendlyFireFlag = new StateFlag("fg-friendly-fire", false);
 
         Class<?> worldGuardPluginClass = Reflections.getClass("com.sk89q.worldguard.bukkit.WorldGuardPlugin");
 
@@ -63,6 +65,7 @@ public class WorldGuard6Hook extends WorldGuardHook {
         try {
             ((FlagRegistry) getFlagRegistry.invoke(getInstance.invoke(null))).register(this.noPointsFlag);
             ((FlagRegistry) getFlagRegistry.invoke(getInstance.invoke(null))).register(this.noGuildsFlag);
+            ((FlagRegistry) getFlagRegistry.invoke(getInstance.invoke(null))).register(this.friendlyFireFlag);
         }
         catch (FlagConflictException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             FunnyGuilds.getPluginLogger().error("An error occurred while registering an \"fg-no-points\" worldguard flag", ex);
@@ -93,6 +96,18 @@ public class WorldGuard6Hook extends WorldGuardHook {
 
         return PandaStream.of(regionSet.get().getRegions())
                 .find(region -> region.getFlag(this.noGuildsFlag) == StateFlag.State.ALLOW)
+                .isPresent();
+    }
+
+    @Override
+    public boolean isInFriendlyFireRegion(Location location) {
+        Option<ApplicableRegionSet> regionSet = this.getRegionSet(location);
+        if (regionSet.isEmpty()) {
+            return false;
+        }
+
+        return PandaStream.of(regionSet.get().getRegions())
+                .find(region -> region.getFlag(this.friendlyFireFlag) == StateFlag.State.ALLOW)
                 .isPresent();
     }
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/worldguard/WorldGuard7Hook.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/worldguard/WorldGuard7Hook.java
@@ -20,6 +20,7 @@ public class WorldGuard7Hook extends WorldGuardHook {
     private WorldGuard worldGuard;
     private StateFlag noPointsFlag;
     private StateFlag noGuildsFlag;
+    private StateFlag friendlyFireFlag;
 
     public WorldGuard7Hook(String name) {
         super(name);
@@ -30,9 +31,11 @@ public class WorldGuard7Hook extends WorldGuardHook {
         this.worldGuard = WorldGuard.getInstance();
         this.noPointsFlag = new StateFlag("fg-no-points", false);
         this.noGuildsFlag = new StateFlag("fg-no-guilds", false);
+        this.friendlyFireFlag = new StateFlag("fg-friendly-fire", false);
 
         this.worldGuard.getFlagRegistry().register(this.noPointsFlag);
         this.worldGuard.getFlagRegistry().register(this.noGuildsFlag);
+        this.worldGuard.getFlagRegistry().register(this.friendlyFireFlag);
         return HookInitResult.SUCCESS;
     }
 
@@ -57,6 +60,18 @@ public class WorldGuard7Hook extends WorldGuardHook {
 
         return PandaStream.of(regionSet.get().getRegions())
                 .find(region -> region.getFlag(this.noGuildsFlag) == StateFlag.State.ALLOW)
+                .isPresent();
+    }
+
+    @Override
+    public boolean isInFriendlyFireRegion(Location location) {
+        Option<ApplicableRegionSet> regionSet = this.getRegionSet(location);
+        if (regionSet.isEmpty()) {
+            return false;
+        }
+
+        return PandaStream.of(regionSet.get().getRegions())
+                .find(region -> region.getFlag(this.friendlyFireFlag) == StateFlag.State.ALLOW)
                 .isPresent();
     }
 

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/worldguard/WorldGuardHook.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/worldguard/WorldGuardHook.java
@@ -18,12 +18,18 @@ public abstract class WorldGuardHook extends AbstractPluginHook {
 
     public abstract boolean isInNonGuildsRegion(Location location);
 
-    public abstract boolean isInFriendlyFireRegion(Location location);
+    public abstract FriendlyFireStatus getFriendlyFireStatus(Location location);
 
     public abstract boolean isInRegion(Location location);
 
     public abstract Option<ApplicableRegionSet> getRegionSet(Location location);
 
     public abstract List<String> getRegionNames(Location location);
+
+    public enum FriendlyFireStatus {
+        ALLOW,
+        DENY,
+        INHERIT
+    }
 
 }

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/worldguard/WorldGuardHook.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/feature/hooks/worldguard/WorldGuardHook.java
@@ -18,6 +18,8 @@ public abstract class WorldGuardHook extends AbstractPluginHook {
 
     public abstract boolean isInNonGuildsRegion(Location location);
 
+    public abstract boolean isInFriendlyFireRegion(Location location);
+
     public abstract boolean isInRegion(Location location);
 
     public abstract Option<ApplicableRegionSet> getRegionSet(Location location);


### PR DESCRIPTION
Well... Simple WG flag (`fg-friendly-fire`) to allow players in the same guild (or allies) to damage each other regardless of their pvp setting. I think It's usefull for e.g. mass pvp events, or duels, where every player should be able to damage everyone, even his own guild-mates.