### PR TITLE
GH-2619 Fix 1.20 NMS support

### DIFF
--- a/nms/v1_20R1/build.gradle.kts
+++ b/nms/v1_20R1/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
     implementation(project(":nms:api"))
 
-    paperweight.paperDevBundle("1.20.1-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.20-R0.1-SNAPSHOT")
 }

--- a/nms/v1_20R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_20R1/packet/V1_20R1FunnyGuildsInboundChannelHandler.java
+++ b/nms/v1_20R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_20R1/packet/V1_20R1FunnyGuildsInboundChannelHandler.java
@@ -5,6 +5,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import net.dzikoysk.funnyguilds.nms.api.packet.FunnyGuildsInboundChannelHandler;
 import net.dzikoysk.funnyguilds.nms.api.packet.PacketCallbacksRegistry;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket.ActionType;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +19,7 @@ public class V1_20R1FunnyGuildsInboundChannelHandler extends ChannelInboundHandl
         if (msg instanceof ServerboundInteractPacket interactPacket) {
             int entityId = interactPacket.getEntityId();
 
-            if (interactPacket.isAttack()) {
+            if (interactPacket.getActionType() == ActionType.ATTACK) {
                 this.packetCallbacksRegistry.handleAttackEntity(entityId, true);
             }
             else {

--- a/nms/v1_20R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_20R1/playerlist/V1_20R1PlayerList.java
+++ b/nms/v1_20R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_20R1/playerlist/V1_20R1PlayerList.java
@@ -13,7 +13,6 @@ import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket.Action;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket.Entry;
 import net.minecraft.network.protocol.game.ClientboundTabListPacket;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.GameType;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;

--- a/nms/v1_20R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_20R1/playerlist/V1_20R1PlayerList.java
+++ b/nms/v1_20R1/src/main/java/net/dzikoysk/funnyguilds/nms/v1_20R1/playerlist/V1_20R1PlayerList.java
@@ -2,6 +2,7 @@ package net.dzikoysk.funnyguilds.nms.v1_20R1.playerlist;
 
 import com.google.common.collect.Lists;
 import com.mojang.authlib.GameProfile;
+import java.util.Collections;
 import net.dzikoysk.funnyguilds.nms.api.ProtocolDependentHelper;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerList;
 import net.dzikoysk.funnyguilds.nms.api.playerlist.PlayerListConstants;
@@ -12,6 +13,7 @@ import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket.Action;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket.Entry;
 import net.minecraft.network.protocol.game.ClientboundTabListPacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.GameType;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;
@@ -152,7 +154,7 @@ public class V1_20R1PlayerList implements PlayerList {
         // NOTE: this whole hack exists just because Mojang does stupid things and collects list of entries
         //       into an immutable list without any ability to modify or pass direct entries through constructor.
         ClientboundPlayerInfoUpdatePacket playerInfoPacket =
-                new ClientboundPlayerInfoUpdatePacket(actions, List.<Entry>of());
+                new ClientboundPlayerInfoUpdatePacket(actions, Collections.emptyList());
 
         try {
             playerInfoEntriesField.set(playerInfoPacket, entries);


### PR DESCRIPTION
1. There is no `ServerboundInteractPacket#isAttack` on 1.20, it was added in 1.20.1
2. The currently used `ClientboundPlayerInfoUpdatePacket` constructor was added in 1.20.1

-----

`ClientboundPlayerInfoUpdatePacket` constructors on 1.20:

```java
public ClientboundPlayerInfoUpdatePacket(EnumSet<Action> actions, Collection<ServerPlayer> players) {
    this.actions = actions;
    this.entries = players.stream().map(Entry::new).toList();
}

public ClientboundPlayerInfoUpdatePacket(Action action, ServerPlayer player) {
    this.actions = EnumSet.of(action);
    this.entries = List.of(new Entry(player));
}
```

`ClientboundPlayerInfoUpdatePacket` constructors on 1.20.1:

```java
public ClientboundPlayerInfoUpdatePacket(EnumSet<Action> actions, Collection<ServerPlayer> players) {
    this.actions = actions;
    this.entries = players.stream().map(Entry::new).toList();
}

public ClientboundPlayerInfoUpdatePacket(Action action, ServerPlayer player) {
    this.actions = EnumSet.of(action);
    this.entries = List.of(new Entry(player));
}

public ClientboundPlayerInfoUpdatePacket(EnumSet<Action> actions, List<Entry> entries) {
    this.actions = actions;
    this.entries = entries;
}

public ClientboundPlayerInfoUpdatePacket(EnumSet<Action> actions, Entry entry) {
    this.actions = actions;
    this.entries = List.of(entry);
}
```