### PR TITLE
Add top placeholder subtypes

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/message/FunnyMessageDispatcher.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/message/FunnyMessageDispatcher.java
@@ -48,7 +48,7 @@ public class FunnyMessageDispatcher extends BukkitMessageDispatcher<FunnyMessage
     }
 
     public FunnyMessageDispatcher receiver(Guild guild) {
-        return this.receivers(guild.getOnlineMembers());
+        return this.receivers(guild.getOnlineMembers(true));
     }
 
 }

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/guild/Guild.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/guild/Guild.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntFunction;
+import java.util.stream.Collectors;
 import net.dzikoysk.funnyguilds.FunnyGuilds;
 import net.dzikoysk.funnyguilds.data.AbstractMutableEntity;
 import net.dzikoysk.funnyguilds.user.User;
@@ -14,7 +15,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 import panda.std.Option;
-import panda.std.stream.PandaStream;
 
 public class Guild extends AbstractMutableEntity {
 
@@ -185,10 +185,11 @@ public class Guild extends AbstractMutableEntity {
         return this.members;
     }
 
-    public Set<User> getOnlineMembers() {
-        return PandaStream.of(this.members)
-                .filter(User::isOnline)
-                .toSet();
+    public Set<User> getOnlineMembers(boolean includeVanished) {
+        return this.members.stream()
+            .filter(User::isOnline)
+            .filter(user -> includeVanished || !user.isVanished())
+            .collect(Collectors.toSet());
     }
 
     public boolean isMember(User user) {

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/guild/placeholders/GuildPlaceholdersService.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/guild/placeholders/GuildPlaceholdersService.java
@@ -80,7 +80,7 @@ public class GuildPlaceholdersService extends StaticPlaceholdersService<Guild, G
                         entity -> messages.get(entity, config -> config.gDeputyNoValue))
                 .property("members", (entity, guild) -> ComponentUtil.join(UserUtils.getOnlineNames(guild.getMembers()), ", "), 
                         entity -> messages.get(entity, config -> config.gMembersNoValue))
-                .property("members-online", guild -> guild.getOnlineMembers().size(), entity -> 0)
+                .property("members-online", guild -> guild.getOnlineMembers(true).size(), entity -> 0)
                 .property("members-all", guild -> guild.getMembers().size(), entity -> 0)
                 .property("allies", 
                         (entity, guild) -> {

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerDeath.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/listener/PlayerDeath.java
@@ -333,10 +333,10 @@ public class PlayerDeath extends AbstractFunnyListener {
 
         switch (this.config.deathMessageReceivers) {
             case GUILD:
-                attacker.getGuild().peek(guild -> receivers.addAll(guild.getOnlineMembers()));
-                victim.getGuild().peek(guild -> receivers.addAll(guild.getOnlineMembers()));
+                attacker.getGuild().peek(guild -> receivers.addAll(guild.getOnlineMembers(true)));
+                victim.getGuild().peek(guild -> receivers.addAll(guild.getOnlineMembers(true)));
                 calculatedAssists.keySet()
-                        .forEach(user -> user.getGuild().peek(guild -> receivers.addAll(guild.getOnlineMembers())));
+                        .forEach(user -> user.getGuild().peek(guild -> receivers.addAll(guild.getOnlineMembers(true))));
                 break;
             case WORLD:
                 event.getEntity()

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/rank/placeholders/RankPlaceholdersService.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/rank/placeholders/RankPlaceholdersService.java
@@ -1,37 +1,19 @@
 package net.dzikoysk.funnyguilds.rank.placeholders;
 
 import dev.peri.yetanothermessageslibrary.replace.Replaceable;
-import dev.peri.yetanothermessageslibrary.replace.replacement.ComponentReplacement;
-import java.util.List;
 import java.util.Locale;
 import java.util.function.UnaryOperator;
-import java.util.regex.Pattern;
-import net.dzikoysk.funnyguilds.FunnyGuilds;
-import net.dzikoysk.funnyguilds.config.NumberRange;
 import net.dzikoysk.funnyguilds.config.PluginConfiguration;
-import net.dzikoysk.funnyguilds.config.RangeFormatting;
 import net.dzikoysk.funnyguilds.config.message.EntityLocaleProvider;
 import net.dzikoysk.funnyguilds.config.message.MessageService;
 import net.dzikoysk.funnyguilds.feature.placeholders.PlaceholdersService;
-import net.dzikoysk.funnyguilds.guild.Guild;
 import net.dzikoysk.funnyguilds.guild.GuildRankManager;
-import net.dzikoysk.funnyguilds.guild.top.GuildTop;
-import net.dzikoysk.funnyguilds.shared.adventure.ComponentUtil;
 import net.dzikoysk.funnyguilds.shared.formatter.FunnyFormatter;
 import net.dzikoysk.funnyguilds.user.User;
 import net.dzikoysk.funnyguilds.user.UserRankManager;
-import net.dzikoysk.funnyguilds.user.top.UserTop;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextReplacementConfig;
-import net.kyori.adventure.text.format.TextColor;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import panda.std.Option;
 
 public class RankPlaceholdersService implements PlaceholdersService<User> {
-
-    private static final Pattern TOP_PATTERN = Pattern.compile("\\{(PTOP|GTOP)-([A-Za-z_]+)-([0-9]+)}");
-    private static final Pattern TOP_POSITION_PATTERN = Pattern.compile("\\{(POSITION|G-POSITION)-([A-Za-z_]+)}");
 
     private final EntityLocaleProvider entityLocaleProvider;
 
@@ -41,11 +23,11 @@ public class RankPlaceholdersService implements PlaceholdersService<User> {
     private final GuildRankManager guildRankManager;
 
     public RankPlaceholdersService(
-            EntityLocaleProvider entityLocaleProvider,
-            PluginConfiguration config,
-            MessageService messageService,
-            UserRankManager userRankManager,
-            GuildRankManager guildRankManager
+        EntityLocaleProvider entityLocaleProvider,
+        PluginConfiguration config,
+        MessageService messageService,
+        UserRankManager userRankManager,
+        GuildRankManager guildRankManager
     ) {
         this.entityLocaleProvider = entityLocaleProvider;
         this.config = config;
@@ -55,298 +37,10 @@ public class RankPlaceholdersService implements PlaceholdersService<User> {
     }
 
     @Override
-    public Replaceable asReplaceable(
-            User targetUser,
-            String prefix,
-            String suffix,
-            UnaryOperator<String> nameModifier
-    ) {
-        ComponentReplacement topReplacement = new ComponentReplacement(TOP_PATTERN) {
-            @Override
-            public @NotNull TextReplacementConfig getReplacement(@Nullable Locale locale) {
-                return this.newReplacementBuilder()
-                        .replacement((matchResult, builder) -> {
-                            String topType = matchResult.group(1);
-                            String comparatorType = matchResult.group(2);
-                            String indexString = matchResult.group(3);
-                            Option<Integer> indexOption = Option.supplyThrowing(
-                                    NumberFormatException.class,
-                                    () -> Integer.parseInt(indexString)
-                            );
-                            if (indexOption.isEmpty()) {
-                                FunnyGuilds.getPluginLogger().error(indexString + "is invalid " + topType + " index!");
-                                return builder;
-                            }
-
-                            int index = indexOption.get();
-                            if (index < 1) {
-                                FunnyGuilds.getPluginLogger().error("Index in " +
-                                                                    topType +
-                                                                    " must be greater or equal to 1!");
-                                return builder;
-                            }
-
-                            switch (topType.toUpperCase(Locale.ROOT)) {
-                                case "PTOP" -> {
-                                    return RankPlaceholdersService.this.getPlayerTopComponent(
-                                            comparatorType,
-                                            index,
-                                            targetUser
-                                    );
-                                }
-                                case "GTOP" -> {
-                                    return RankPlaceholdersService.this.getGuildTopComponent(
-                                            comparatorType,
-                                            index,
-                                            targetUser
-                                    );
-                                }
-                                default -> {
-                                    return Component.empty();
-                                }
-                            }
-                        })
-                        .build();
-            }
-        };
-
-        ComponentReplacement topPositionReplacement = new ComponentReplacement(TOP_POSITION_PATTERN) {
-            @Override
-            public @NotNull TextReplacementConfig getReplacement(@Nullable Locale locale) {
-                return this.newReplacementBuilder()
-                        .replacement((matchResult, builder) -> {
-                            String positionType = matchResult.group(1);
-                            String comparatorType = matchResult.group(2);
-
-                            switch (positionType.toUpperCase(Locale.ROOT)) {
-                                case "POSITION" -> {
-                                    return getPlayerPositionComponent(
-                                            comparatorType,
-                                            targetUser
-                                    );
-                                }
-                                case "G-POSITION" -> {
-                                    return RankPlaceholdersService.this.getGuildPositionComponent(
-                                            comparatorType,
-                                            targetUser
-                                    );
-                                }
-                                default -> {
-                                    return Component.empty();
-                                }
-                            }
-                        })
-                        .build();
-            }
-        };
-        
+    public Replaceable asReplaceable(User targetUser, String prefix, String suffix, UnaryOperator<String> nameModifier) {
         return new FunnyFormatter()
-                .register(topReplacement)
-                .register(topPositionReplacement);
-    }
-
-    private Component getPlayerTopComponent(
-            String comparatorType,
-            int index,
-            User targetUser
-    ) {
-        Component noValue = this.messageService.getComponent(
-                targetUser,
-                config -> config.ptopNoValue
-        );
-
-        Option<UserTop> userTopOption = this.userRankManager.getTop(comparatorType);
-        if (userTopOption.isEmpty()) {
-            return noValue;
-        }
-        UserTop userTop = userTopOption.get();
-
-        Option<User> userOption = userTop.getUser(index);
-        if (userOption.isEmpty()) {
-            return noValue;
-        }
-        User user = userOption.get();
-
-        Number topValue = userTop.getComparator().getValue(user.getRank());
-        return this.formatUserTop(
-                user,
-                topValue,
-                this.config.top.format.ptop,
-                this.config.top.format.ptopValueFormatting.get(comparatorType.toLowerCase(Locale.ROOT))
-        );
-    }
-
-    private Component getGuildTopComponent(
-            String comparatorType,
-            int index,
-            User targetUser
-    ) {
-        Component noValue = this.messageService.getComponent(
-                targetUser,
-                config -> config.gtopNoValue
-        );
-
-        Option<GuildTop> guildTopOption = this.guildRankManager.getTop(comparatorType);
-        if (guildTopOption.isEmpty()) {
-            return noValue;
-        }
-        GuildTop guildTop = guildTopOption.get();
-
-        Option<Guild> guildOption = guildTop.getGuild(index);
-        if (guildOption.isEmpty()) {
-            return noValue;
-        }
-        Guild guild = guildOption.get();
-
-        Number topValue = guildTop.getComparator().getValue(guild.getRank());
-        return this.formatGuildTop(
-                targetUser,
-                guild,
-                topValue,
-                this.config.top.format.gtop,
-                this.config.top.format.gtopValueFormatting.get(comparatorType.toLowerCase(Locale.ROOT))
-        );
-    }
-    
-    private Component formatUserTop(
-            User user,
-            Number topValue,
-            String topFormat,
-            @Nullable List<RangeFormatting> formats
-    ) {
-        boolean online = user.isOnline();
-        if (online && this.config.ptopRespectVanish) {
-            online = !user.isVanished();
-        }
-        TextColor applicableColor = online
-                ? this.config.onlineColor
-                : this.config.offlineColor;
-
-        Component userNameComponent = Component.text(
-                user.getName(),
-                applicableColor
-        );
-        Component topValueComponent = formatTopValue(
-                topValue,
-                topFormat,
-                formats
-        );
-
-        return userNameComponent.append(topValueComponent);
-    }
-
-    private Component formatGuildTop(
-            User targetUser,
-            Guild guild,
-            Number topValue,
-            String topFormat,
-            @Nullable List<RangeFormatting> formats
-    ) {
-        Component guildTagComponent = null;
-        if (this.config.top.useRelationshipColors && targetUser != null) {
-            Guild viewerGuild = targetUser.getGuild().orNull();
-            if (viewerGuild != null) {
-                guildTagComponent = this.config.relationalTag.chooseAndPrepareTag(
-                        viewerGuild,
-                        guild
-                );
-            }
-        }
-
-        if (guildTagComponent == null) {
-            boolean hasOnlineMembers = guild.getMembers().stream()
-                    .anyMatch(member -> {
-                        boolean online = member.isOnline();
-                        if (online && this.config.gtopRespectVanish) {
-                            online = !member.isVanished();
-                        }
-                        return online;
-                    });
-            TextColor tagColor = hasOnlineMembers
-                    ? this.config.onlineColor
-                    : this.config.offlineColor;
-            guildTagComponent = Component.text(
-                    guild.getTag(),
-                    tagColor
-            );
-        }
-
-        Component topValueComponent = formatTopValue(
-                topValue,
-                topFormat,
-                formats
-        );
-        return guildTagComponent.append(topValueComponent);
-    }
-    
-    private static Component formatTopValue(
-            Number topValue,
-            String topFormat,
-            @Nullable List<RangeFormatting> formats
-    ) {
-        String valueString = topValue instanceof Float || topValue instanceof Double
-                ? String.format(
-                Locale.US,
-                "%.2f",
-                topValue.floatValue()
-        )
-                : topValue.toString();
-        String valueFormat = formats == null
-                ? valueString
-                : NumberRange.inRangeToString(
-                        topValue,
-                        formats
-                );
-
-        String rawTopFormat = topFormat
-                .replace(
-                        "{VALUE-FORMAT}",
-                        valueFormat
-                )
-                .replace(
-                        "{VALUE}",
-                        valueString
-                );
-
-        return ComponentUtil.colored(rawTopFormat);
-    }
-
-    private static Component getPlayerPositionComponent(
-            String comparatorType,
-            User targetUser
-    ) {
-        if (targetUser == null) {
-            return ComponentUtil.toComponent(0);
-        }
-
-        int position = targetUser.getRank().getPosition(comparatorType);
-        return ComponentUtil.toComponent(position);
-    }
-
-    private Component getGuildPositionComponent(
-            String comparatorType,
-            User targetUser
-    ) {
-        Component minMembersToIncludeNoValue = this.messageService.getComponent(
-                targetUser,
-                config -> config.minMembersToIncludeNoValue
-        );
-        if (targetUser == null) {
-            return minMembersToIncludeNoValue;
-        }
-
-        Option<Guild> guildOption = targetUser.getGuild();
-        if (guildOption.isEmpty()) {
-            return minMembersToIncludeNoValue;
-        }
-        Guild guild = guildOption.get();
-
-        if (!this.guildRankManager.isRankedGuild(guild)) {
-            return minMembersToIncludeNoValue;
-        }
-
-        int position = guild.getRank().getPosition(comparatorType);
-        return ComponentUtil.toComponent(position);
+            .register(new TopPlaceholderReplacement(config, messageService, userRankManager, guildRankManager, targetUser))
+            .register(new TopPositionPlaceholderReplacement(messageService, guildRankManager, targetUser));
     }
 
     @Override

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/rank/placeholders/TopPlaceholderReplacement.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/rank/placeholders/TopPlaceholderReplacement.java
@@ -152,7 +152,6 @@ public class TopPlaceholderReplacement extends ComponentReplacement {
         return switch (subType) {
             case "NAME" -> Component.text(guild.getName());
             case "TAG" -> Component.text(guild.getTag());
-            case "UUID" -> Component.text(guild.getUUID().toString());
             case "VALUE" -> Component.text(rawValueString(topValue));
             default -> Component.empty();
         };

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/rank/placeholders/TopPlaceholderReplacement.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/rank/placeholders/TopPlaceholderReplacement.java
@@ -1,0 +1,214 @@
+package net.dzikoysk.funnyguilds.rank.placeholders;
+
+import dev.peri.yetanothermessageslibrary.replace.replacement.ComponentReplacement;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import net.dzikoysk.funnyguilds.FunnyGuilds;
+import net.dzikoysk.funnyguilds.config.NumberRange;
+import net.dzikoysk.funnyguilds.config.PluginConfiguration;
+import net.dzikoysk.funnyguilds.config.RangeFormatting;
+import net.dzikoysk.funnyguilds.config.message.MessageService;
+import net.dzikoysk.funnyguilds.guild.Guild;
+import net.dzikoysk.funnyguilds.guild.GuildRankManager;
+import net.dzikoysk.funnyguilds.guild.top.GuildTop;
+import net.dzikoysk.funnyguilds.shared.adventure.ComponentUtil;
+import net.dzikoysk.funnyguilds.user.User;
+import net.dzikoysk.funnyguilds.user.UserRankManager;
+import net.dzikoysk.funnyguilds.user.top.UserTop;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextReplacementConfig;
+import net.kyori.adventure.text.format.TextColor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import panda.std.Option;
+
+public class TopPlaceholderReplacement extends ComponentReplacement {
+
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile(
+        "\\{(PTOP|GTOP)-([A-Za-z_]+)-([0-9]+)(?:-(NAME|TAG|UUID|VALUE))?}",
+        Pattern.CASE_INSENSITIVE
+    );
+
+    private final PluginConfiguration config;
+    private final MessageService messageService;
+    private final UserRankManager userRankManager;
+    private final GuildRankManager guildRankManager;
+    private final User targetUser;
+
+    TopPlaceholderReplacement(
+        PluginConfiguration config,
+        MessageService messageService,
+        UserRankManager userRankManager,
+        GuildRankManager guildRankManager,
+        User targetUser
+    ) {
+        super(PLACEHOLDER_PATTERN);
+        this.config = config;
+        this.messageService = messageService;
+        this.userRankManager = userRankManager;
+        this.guildRankManager = guildRankManager;
+        this.targetUser = targetUser;
+    }
+
+    @Override
+    public @NotNull TextReplacementConfig getReplacement(@Nullable Locale locale) {
+        return this.newReplacementBuilder()
+            .replacement((matchResult, builder) -> {
+                String topType = matchResult.group(1);
+                String comparatorType = matchResult.group(2);
+                String indexString = matchResult.group(3);
+                String subType = matchResult.group(4) == null
+                    ? null
+                    : matchResult.group(4).toUpperCase(Locale.ROOT);
+
+                Option<Integer> indexOption = Option.supplyThrowing(NumberFormatException.class, () -> Integer.parseInt(indexString));
+                if (indexOption.isEmpty()) {
+                    FunnyGuilds.getPluginLogger().error(indexString + "is invalid " + topType + " index!");
+                    return builder;
+                }
+
+                int index = indexOption.get();
+                if (index < 1) {
+                    FunnyGuilds.getPluginLogger().error("Index in " + topType + " must be greater or equal to 1!");
+                    return builder;
+                }
+
+                return switch (topType.toUpperCase(Locale.ROOT)) {
+                    case "PTOP" ->  this.getPlayerTopComponent(comparatorType, index, subType, targetUser);
+                    case "GTOP" -> this.getGuildTopComponent(comparatorType, index, subType, targetUser);
+                    default -> Component.empty();
+                };
+            }).build();
+    }
+
+    private Component getPlayerTopComponent(String comparatorType, int index, String subType, User targetUser) {
+        Component noValue = this.messageService.getComponent(
+            targetUser,
+            config -> config.ptopNoValue
+        );
+
+        Option<UserTop> userTopOption = this.userRankManager.getTop(comparatorType);
+        if (userTopOption.isEmpty()) {
+            return noValue;
+        }
+
+        UserTop userTop = userTopOption.get();
+        Option<User> userOption = userTop.getUser(index);
+        if (userOption.isEmpty()) {
+            return noValue;
+        }
+
+        User user = userOption.get();
+        Number topValue = userTop.getComparator().getValue(user.getRank());
+
+        if (subType == null) {
+            return this.formatUserTop(
+                user,
+                topValue,
+                this.config.top.format.ptop,
+                this.config.top.format.ptopValueFormatting.get(comparatorType.toLowerCase(Locale.ROOT))
+            );
+        }
+
+        return switch (subType) {
+            case "NAME" -> Component.text(user.getName());
+            case "UUID" -> Component.text(user.getUUID().toString());
+            case "VALUE" -> Component.text(rawValueString(topValue));
+            default -> Component.empty();
+        };
+    }
+
+    private Component getGuildTopComponent(String comparatorType, int index, String subType, User targetUser) {
+        Component noValue = this.messageService.getComponent(
+            targetUser,
+            config -> config.gtopNoValue
+        );
+
+        Option<GuildTop> guildTopOption = this.guildRankManager.getTop(comparatorType);
+        if (guildTopOption.isEmpty()) {
+            return noValue;
+        }
+
+        GuildTop guildTop = guildTopOption.get();
+        Option<Guild> guildOption = guildTop.getGuild(index);
+        if (guildOption.isEmpty()) {
+            return noValue;
+        }
+
+        Guild guild = guildOption.get();
+        Number topValue = guildTop.getComparator().getValue(guild.getRank());
+
+        if (subType == null) {
+            return this.formatGuildTop(
+                targetUser,
+                guild,
+                topValue,
+                this.config.top.format.gtop,
+                this.config.top.format.gtopValueFormatting.get(comparatorType.toLowerCase(Locale.ROOT))
+            );
+        }
+
+        return switch (subType) {
+            case "NAME" -> Component.text(guild.getName());
+            case "TAG" -> Component.text(guild.getTag());
+            case "UUID" -> Component.text(guild.getUUID().toString());
+            case "VALUE" -> Component.text(rawValueString(topValue));
+            default -> Component.empty();
+        };
+    }
+
+    private Component formatUserTop(User user, Number topValue, String topFormat, @Nullable List<RangeFormatting> formats) {
+        boolean online = user.isOnline();
+        if (online && this.config.ptopRespectVanish) {
+            online = !user.isVanished();
+        }
+
+        Component userNameComponent = Component.text(
+            user.getName(),
+            online ? this.config.onlineColor : this.config.offlineColor
+        );
+        return userNameComponent.append(formatTopValue(topValue, topFormat, formats));
+    }
+
+    private Component formatGuildTop(
+        User targetUser,
+        Guild guild,
+        Number topValue,
+        String topFormat,
+        @Nullable List<RangeFormatting> formats
+    ) {
+        Component guildTagComponent = null;
+        if (this.config.top.useRelationshipColors && targetUser != null) {
+            Guild viewerGuild = targetUser.getGuild().orNull();
+            if (viewerGuild != null) {
+                guildTagComponent = this.config.relationalTag.chooseAndPrepareTag(viewerGuild, guild);
+            }
+        }
+
+        if (guildTagComponent == null) {
+            TextColor tagColor = !guild.getOnlineMembers(!this.config.gtopRespectVanish).isEmpty()
+                ? this.config.onlineColor
+                : this.config.offlineColor;
+            guildTagComponent = Component.text(guild.getTag(), tagColor);
+        }
+
+        return guildTagComponent.append(formatTopValue(topValue, topFormat, formats));
+    }
+
+    private Component formatTopValue(Number topValue, String topFormat, @Nullable List<RangeFormatting> formats) {
+        String valueString = rawValueString(topValue);
+        String valueFormat = formats == null ? valueString : NumberRange.inRangeToString(topValue, formats);
+        String rawTopFormat = topFormat
+            .replace("{VALUE-FORMAT}", valueFormat)
+            .replace("{VALUE}", valueString);
+
+        return ComponentUtil.colored(rawTopFormat);
+    }
+
+    private String rawValueString(Number topValue) {
+        return topValue instanceof Float || topValue instanceof Double
+            ? String.format(Locale.US, "%.2f", topValue.floatValue())
+            : topValue.toString();
+    }
+}

--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/rank/placeholders/TopPositionPlaceholderReplacement.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/rank/placeholders/TopPositionPlaceholderReplacement.java
@@ -1,0 +1,79 @@
+package net.dzikoysk.funnyguilds.rank.placeholders;
+
+import dev.peri.yetanothermessageslibrary.replace.replacement.ComponentReplacement;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import net.dzikoysk.funnyguilds.config.message.MessageService;
+import net.dzikoysk.funnyguilds.guild.Guild;
+import net.dzikoysk.funnyguilds.guild.GuildRankManager;
+import net.dzikoysk.funnyguilds.shared.adventure.ComponentUtil;
+import net.dzikoysk.funnyguilds.user.User;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextReplacementConfig;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import panda.std.Option;
+
+public class TopPositionPlaceholderReplacement extends ComponentReplacement {
+
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{(POSITION|G-POSITION)-([A-Za-z_]+)}");
+
+    private final MessageService messageService;
+    private final GuildRankManager guildRankManager;
+    private final User targetUser;
+
+    TopPositionPlaceholderReplacement(MessageService messageService, GuildRankManager guildRankManager, User targetUser) {
+        super(PLACEHOLDER_PATTERN);
+        this.messageService = messageService;
+        this.guildRankManager = guildRankManager;
+        this.targetUser = targetUser;
+    }
+
+    @Override
+    public @NotNull TextReplacementConfig getReplacement(@Nullable Locale locale) {
+        return this.newReplacementBuilder()
+            .replacement((matchResult, builder) -> {
+                String positionType = matchResult.group(1);
+                String comparatorType = matchResult.group(2);
+
+                return switch (positionType.toUpperCase(Locale.ROOT)) {
+                    case "POSITION" -> this.getPlayerPositionComponent(comparatorType, targetUser);
+                    case "G-POSITION" -> this.getGuildPositionComponent(comparatorType, targetUser);
+                    default -> Component.empty();
+                };
+            }).build();
+    }
+
+    private Component getPlayerPositionComponent(String comparatorType, User targetUser) {
+        if (targetUser == null) {
+            return ComponentUtil.toComponent(0);
+        }
+
+        int position = targetUser.getRank().getPosition(comparatorType);
+        return ComponentUtil.toComponent(position);
+    }
+
+    private Component getGuildPositionComponent(String comparatorType, User targetUser) {
+        Component minMembersToIncludeNoValue = this.messageService.getComponent(
+            targetUser,
+            config -> config.minMembersToIncludeNoValue
+        );
+
+        if (targetUser == null) {
+            return minMembersToIncludeNoValue;
+        }
+
+        Option<Guild> guildOption = targetUser.getGuild();
+        if (guildOption.isEmpty()) {
+            return minMembersToIncludeNoValue;
+        }
+
+        Guild guild = guildOption.get();
+        if (!this.guildRankManager.isRankedGuild(guild)) {
+            return minMembersToIncludeNoValue;
+        }
+
+        int position = guild.getRank().getPosition(comparatorType);
+        return ComponentUtil.toComponent(position);
+    }
+}


### PR DESCRIPTION
New possible `PTOP` placeholders added:
- `PTOP-type-x-name`
- `PTOP-type-x-uuid`
- `PTOP-type-x-value`

New possible `GTOP` placeholders added:
- `GTOP-type-x-tag`
- `GTOP-type-x-name`
- `GTOP-type-x-value`

Current `PTOP-type-x` and `GTOP-type-x` placeholders preserve their behaviour.