### PR TITLE
Stop using legacy ampersand method

### DIFF
--- a/plugin/src/main/java/net/dzikoysk/funnyguilds/config/PluginConfiguration.java
+++ b/plugin/src/main/java/net/dzikoysk/funnyguilds/config/PluginConfiguration.java
@@ -69,8 +69,8 @@ import panda.std.Option;
 public class PluginConfiguration extends OkaeriConfig {
     
     @Exclude
-    private static final LegacyComponentSerializer AMPERSAND_SERIALIZER = LegacyComponentSerializer.legacyAmpersand()
-            .toBuilder()
+    private static final LegacyComponentSerializer AMPERSAND_SERIALIZER = LegacyComponentSerializer.builder()
+            .character('&')
             .hexColors()
             .build();
 


### PR DESCRIPTION
I've stumbled upon Kyori's legacy ampersand method, which no longer exists in newer Paper versions (such as 26.2):
```[16:38:24] [Server thread/INFO]: [FunnyGuilds] Loading server plugin FunnyGuilds v5.0.0-SNAPSHOT Primrose-da75e3c
[16:38:24] [Server thread/ERROR]: [FunnyGuilds] Error initializing plugin 'FunnyGuilds 5.0.0-SNAPSHOT.1816 (MC 1.21.x).jar' in folder 'plugins' (Is it up to date?)
java.lang.NoSuchMethodError: 'net.kyori.adventure.util.Buildable$Builder net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.toBuilder()'
	at FunnyGuilds 5.0.0-SNAPSHOT.1816 (MC 1.21.x).jar//net.dzikoysk.funnyguilds.config.PluginConfiguration.<clinit>(PluginConfiguration.java:73) ~[?:?]
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method) ~[?:?]
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1169) ~[?:?]
	at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.ensureClassInitialized(MethodHandleAccessorFactory.java:341) ~[?:?]
	at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newConstructorAccessor(MethodHandleAccessorFactory.java:104) ~[?:?]
	at java.base/jdk.internal.reflect.ReflectionFactory.newConstructorAccessor(ReflectionFactory.java:138) ~[?:?]
	at java.base/java.lang.reflect.Constructor.acquireConstructorAccessor(Constructor.java:546) ~[?:?]
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:496) ~[?:?]
	at java.base/java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:79) ~[?:?]
	at java.base/jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:189) ~[?:?]
	at java.base/java.lang.Class.newInstance(Class.java:715) ~[?:?]
	at FunnyGuilds 5.0.0-SNAPSHOT.1816 (MC 1.21.x).jar//net.dzikoysk.funnyguilds.libs.eu.okaeri.configs.ConfigManager.create(ConfigManager.java:38) ~[?:?]
	at FunnyGuilds 5.0.0-SNAPSHOT.1816 (MC 1.21.x).jar//net.dzikoysk.funnyguilds.libs.eu.okaeri.configs.ConfigManager.create(ConfigManager.java:76) ~[?:?]
	at FunnyGuilds 5.0.0-SNAPSHOT.1816 (MC 1.21.x).jar//net.dzikoysk.funnyguilds.config.ConfigurationFactory.createPluginConfiguration(ConfigurationFactory.java:52) ~[?:?]
	at FunnyGuilds 5.0.0-SNAPSHOT.1816 (MC 1.21.x).jar//net.dzikoysk.funnyguilds.FunnyGuilds.onLoad(FunnyGuilds.java:202) ~[?:?]
	at io.papermc.paper.plugin.storage.ServerPluginProviderStorage.processProvided(ServerPluginProviderStorage.java:59) ~[paper-26.2.jar:26.2-84-26e81c4]
	at io.papermc.paper.plugin.storage.ServerPluginProviderStorage.processProvided(ServerPluginProviderStorage.java:18) ~[paper-26.2.jar:26.2-84-26e81c4]
	at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:39) ~[paper-26.2.jar:26.2-84-26e81c4]
	at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:39) ~[paper-26.2.jar:26.2-84-26e81c4]
	at org.bukkit.craftbukkit.CraftServer.loadPlugins(CraftServer.java:549) ~[paper-26.2.jar:26.2-84-26e81c4]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:297) ~[paper-26.2.jar:26.2-84-26e81c4]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1267) ~[paper-26.2.jar:26.2-84-26e81c4]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:303) ~[paper-26.2.jar:26.2-84-26e81c4]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```